### PR TITLE
Create historical events landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-#Flask
+# Tarihte Bugün
+
+Minimal ve şık tasarımlı bu Flask uygulaması, Wikipedia'nın "On This Day" API'sinden alınan verilerle bugünün tarihindeki önemli olayları listeler. Uygulama, her biri daha fazla bilgiye yönlendiren bağlantılar içeren şeffaf kartlar üzerinde öne çıkan olayları sunar.
+
+## Geliştirme
+
+```bash
+python app.py
+```
+
+Uygulama varsayılan olarak `http://127.0.0.1:5000` adresinde çalışır.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Tarihte Bugün
-
-Minimal ve şık tasarımlı bu Flask uygulaması, Wikipedia'nın "On This Day" API'sinden alınan verilerle bugünün tarihindeki önemli olayları listeler. Uygulama, her biri daha fazla bilgiye yönlendiren bağlantılar içeren şeffaf kartlar üzerinde öne çıkan olayları sunar.
+Minimal ve şık tasarımlı bu statik web sayfası, Wikipedia'nın "On This Day" API'sinden alınan verilerle bugünün tarihindeki önemli olayları listeler. Sayfa, her biri daha fazla bilgiye yönlendiren bağlantılar içeren şeffaf kartlar üzerinde öne çıkan olayları sunar.
 
 ## Geliştirme
+Yerelde hızlıca incelemek için herhangi bir statik sunucu yeterlidir:
 
 ```bash
-python app.py
+python -m http.server 8000
 ```
 
-Uygulama varsayılan olarak `http://127.0.0.1:5000` adresinde çalışır.
+Ardından tarayıcınızda [`http://127.0.0.1:8000`](http://127.0.0.1:8000) adresini açın.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,67 @@
+from datetime import datetime
+from json import loads
+from typing import List, Dict, Any
+from urllib.error import URLError, HTTPError
+from urllib.request import Request, urlopen
+
 from flask import Flask, render_template
 
 app = Flask(__name__)
 
-@app.route('/')
-def home():
-    return render_template('index.html')
+API_URL = "https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/{month}/{day}"
+USER_AGENT = "TarihteBugunApp/1.0 (https://github.com/zapotec001)"
 
-if __name__ == '__main__':
-    app.run()
+
+def fetch_today_events(limit: int = 4) -> List[Dict[str, Any]]:
+    """Fetch notable events for today's date from Wikipedia."""
+    today = datetime.utcnow()
+    url = API_URL.format(month=today.month, day=today.day)
+
+    request = Request(url, headers={"User-Agent": USER_AGENT})
+
+    try:
+        with urlopen(request, timeout=10) as response:
+            data = loads(response.read().decode("utf-8"))
+    except (URLError, HTTPError, ValueError):
+        return []
+
+    events = data.get("events", [])
+
+    # Sort by the year descending so the most recent events appear first
+    events.sort(key=lambda event: event.get("year", 0), reverse=True)
+
+    formatted_events = []
+    for event in events[:limit]:
+        pages = []
+        for page in event.get("pages", [])[:2]:
+            desktop_url = (
+                (page.get("content_urls") or {}).get("desktop") or {}
+            ).get("page")
+            title = (page.get("titles") or {}).get("display") or page.get("title")
+            if desktop_url and title:
+                pages.append({"title": title, "url": desktop_url})
+
+        formatted_events.append(
+            {
+                "year": event.get("year"),
+                "text": event.get("text"),
+                "pages": pages,
+            }
+        )
+
+    return formatted_events
+
+
+@app.route("/")
+def home():
+    events = fetch_today_events()
+    today = datetime.utcnow()
+    return render_template(
+        "index.html",
+        events=events,
+        date_string=today.strftime("%d %B %Y"),
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tarihte Bugün</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="static/style.css">
+    <script defer src="static/script.js"></script>
+</head>
+<body>
+    <header class="hero">
+        <nav class="nav">
+            <div class="logo">Tarihte Bugün</div>
+            <div class="today" data-date></div>
+        </nav>
+        <div class="hero-content">
+            <h1>Bugün Tarihte Neler Oldu?</h1>
+            <p>Wikipedia'nın "Tarihte Bugün" arşivinden seçtiğimiz olayları keşfedin.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="events" id="events" aria-live="polite">
+            <div class="empty-state" id="status" role="status">
+                <h2>Olaylar yükleniyor</h2>
+                <p>Wikipedia'nın Tarihte Bugün arşivi çağrılıyor...</p>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>Veriler <a href="https://www.wikipedia.org/" target="_blank" rel="noopener">Wikipedia</a>'dan alınmıştır.</p>
+    </footer>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,15 +1,8 @@
-document.addEventListener("scroll", () => {
-    const nav = document.querySelector(".nav");
-    if (!nav) return;
+const nav = document.querySelector(".nav");
+let statusElement = document.getElementById("status");
+const eventsContainer = document.getElementById("events");
+const todayElement = document.querySelector("[data-date]");
 
-    if (window.scrollY > 40) {
-        nav.classList.add("nav--scrolled");
-    } else {
-        nav.classList.remove("nav--scrolled");
-    }
-});
-
-// Add a small fade-in effect for cards
 const observer = new IntersectionObserver(
     (entries) => {
         entries.forEach((entry) => {
@@ -22,7 +15,146 @@ const observer = new IntersectionObserver(
     { threshold: 0.2 }
 );
 
-document.querySelectorAll(".event-card").forEach((card) => {
-    card.classList.add("will-animate");
-    observer.observe(card);
+function updateNavOnScroll() {
+    if (!nav) return;
+    if (window.scrollY > 40) {
+        nav.classList.add("nav--scrolled");
+    } else {
+        nav.classList.remove("nav--scrolled");
+    }
+}
+
+document.addEventListener("scroll", updateNavOnScroll);
+
+function formatDate(now = new Date()) {
+    return now.toLocaleDateString("tr-TR", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+function showStatus(title, message, role = "status") {
+    if (!statusElement) {
+        statusElement = document.createElement("div");
+        statusElement.className = "empty-state";
+        statusElement.id = "status";
+        statusElement.setAttribute("role", role);
+        eventsContainer?.appendChild(statusElement);
+    }
+
+    statusElement.innerHTML = `<h2>${title}</h2><p>${message}</p>`;
+    statusElement.setAttribute("role", role);
+}
+
+function clearStatus() {
+    if (statusElement) {
+        statusElement.remove();
+        statusElement = null;
+    }
+}
+
+function createEventCard(event) {
+    const article = document.createElement("article");
+    article.className = "event-card will-animate";
+
+    const year = document.createElement("div");
+    year.className = "event-year";
+    year.textContent = event.year ?? "";
+
+    const text = document.createElement("p");
+    text.className = "event-text";
+    text.textContent = event.text ?? "";
+
+    article.appendChild(year);
+    article.appendChild(text);
+
+    if (Array.isArray(event.pages) && event.pages.length > 0) {
+        const linksWrapper = document.createElement("div");
+        linksWrapper.className = "event-links";
+        linksWrapper.setAttribute("aria-label", "Daha fazla bilgi");
+
+        event.pages.slice(0, 2).forEach((page) => {
+            const url = page?.content_urls?.desktop?.page;
+            const title = page?.titles?.display || page?.title;
+            if (!url || !title) return;
+
+            const link = document.createElement("a");
+            link.href = url;
+            link.target = "_blank";
+            link.rel = "noopener";
+            link.className = "event-link";
+            link.textContent = title;
+            linksWrapper.appendChild(link);
+        });
+
+        if (linksWrapper.children.length > 0) {
+            article.appendChild(linksWrapper);
+        }
+    }
+
+    observer.observe(article);
+    return article;
+}
+
+async function loadEvents(referenceDate = new Date()) {
+    if (!eventsContainer) return;
+
+    showStatus(
+        "Olaylar yükleniyor",
+        "Wikipedia'nın Tarihte Bugün arşivi çağrılıyor..."
+    );
+
+    const month = referenceDate.getMonth() + 1;
+    const day = referenceDate.getDate();
+    const endpoint = `https://en.wikipedia.org/api/rest_v1/feed/onthisday/events/${month}/${day}`;
+
+    try {
+        const response = await fetch(endpoint, {
+            headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+            throw new Error("Yanıt alınamadı");
+        }
+
+        const data = await response.json();
+        const events = Array.isArray(data.events) ? data.events : [];
+
+        const sorted = events
+            .filter((event) => event.text)
+            .sort((a, b) => (b.year || 0) - (a.year || 0))
+            .slice(0, 4);
+
+        if (sorted.length === 0) {
+            showStatus(
+                "Olay bulunamadı",
+                "Bugün için Wikipedia'da listelenen olay yok.",
+                "alert"
+            );
+            return;
+        }
+
+        clearStatus();
+        sorted.forEach((event) => {
+            const card = createEventCard(event);
+            eventsContainer.appendChild(card);
+        });
+    } catch (error) {
+        console.error("Olaylar yüklenirken hata oluştu", error);
+        showStatus(
+            "Olaylar yüklenemedi",
+            "Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.",
+            "alert"
+        );
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const now = new Date();
+    if (todayElement) {
+        todayElement.textContent = formatDate(now);
+    }
+    updateNavOnScroll();
+    loadEvents(now);
 });

--- a/static/script.js
+++ b/static/script.js
@@ -1,15 +1,28 @@
-function updateClock() {
-    var now = new Date();
-    var hours = now.getHours();
-    var minutes = now.getMinutes();
-    var seconds = now.getSeconds();
+document.addEventListener("scroll", () => {
+    const nav = document.querySelector(".nav");
+    if (!nav) return;
 
-    hours = hours.toString().padStart(2, '0');
-    minutes = minutes.toString().padStart(2, '0');
-    seconds = seconds.toString().padStart(2, '0');
+    if (window.scrollY > 40) {
+        nav.classList.add("nav--scrolled");
+    } else {
+        nav.classList.remove("nav--scrolled");
+    }
+});
 
-    var timeString = hours + ':' + minutes + ':' + seconds;
-    document.getElementById('clock').textContent = timeString;
-}
+// Add a small fade-in effect for cards
+const observer = new IntersectionObserver(
+    (entries) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add("is-visible");
+                observer.unobserve(entry.target);
+            }
+        });
+    },
+    { threshold: 0.2 }
+);
 
-setInterval(updateClock, 1000);
+document.querySelectorAll(".event-card").forEach((card) => {
+    card.classList.add("will-animate");
+    observer.observe(card);
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,189 @@
+:root {
+    --bg-gradient-start: #0f2027;
+    --bg-gradient-middle: #203a43;
+    --bg-gradient-end: #2c5364;
+    --card-bg: rgba(255, 255, 255, 0.08);
+    --card-border: rgba(255, 255, 255, 0.25);
+    --accent: #f3c623;
+    --text-primary: #f7f7f7;
+    --text-secondary: rgba(247, 247, 247, 0.75);
+    --link: #8ad6ff;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: "Poppins", sans-serif;
+    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-middle), var(--bg-gradient-end));
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.hero {
+    position: relative;
+    padding: 2rem 4vw 4rem;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent);
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    padding: 1rem 0;
+    backdrop-filter: blur(10px);
+    background: rgba(15, 32, 39, 0.4);
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding-inline: clamp(1rem, 4vw, 2rem);
+}
+
+.logo {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.today {
+    font-weight: 300;
+    color: var(--text-secondary);
+}
+
+.hero-content {
+    margin-top: 6rem;
+    max-width: 640px;
+}
+
+.hero-content h1 {
+    font-size: clamp(2.5rem, 6vw, 3.5rem);
+    margin-bottom: 1rem;
+}
+
+.hero-content p {
+    font-size: clamp(1rem, 2.5vw, 1.2rem);
+    color: var(--text-secondary);
+}
+
+main {
+    flex: 1;
+    padding: 0 4vw 4rem;
+}
+
+.events {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: -3rem;
+}
+
+.event-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 24px;
+    padding: 2rem;
+    backdrop-filter: blur(12px);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.event-card:hover {
+    transform: translateY(-6px);
+    border-color: rgba(243, 198, 35, 0.5);
+}
+
+.event-year {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--accent);
+    margin-bottom: 0.75rem;
+}
+
+.event-text {
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+}
+
+.event-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.event-link {
+    text-decoration: none;
+    color: var(--link);
+    border: 1px solid rgba(138, 214, 255, 0.4);
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.event-link:hover,
+.event-link:focus {
+    background: rgba(138, 214, 255, 0.2);
+    color: #ffffff;
+}
+
+.empty-state {
+    text-align: center;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 24px;
+    padding: 3rem 2rem;
+    backdrop-filter: blur(12px);
+    color: var(--text-secondary);
+}
+
+footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+footer a {
+    color: var(--link);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    .nav {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .hero-content {
+        margin-top: 4rem;
+    }
+
+    .event-card {
+        padding: 1.5rem;
+    }
+}
+
+.nav--scrolled {
+    background: rgba(15, 32, 39, 0.75);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.will-animate {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: transform 0.6s ease, opacity 0.6s ease;
+}
+
+.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,54 @@
 <!DOCTYPE html>
-<html>
+<html lang="tr">
 <head>
-    <title>GitHub Sayfası</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tarihte Bugün</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
-    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <script defer src="{{ url_for('static', filename='script.js') }}"></script>
 </head>
 <body>
-    <h1>GitHub Sayfası</h1>
-    <div id="clock"></div>
+    <header class="hero">
+        <nav class="nav">
+            <div class="logo">Tarihte Bugün</div>
+            <div class="today">{{ date_string }}</div>
+        </nav>
+        <div class="hero-content">
+            <h1>Bugün Tarihte Neler Oldu?</h1>
+            <p>Wikipedia'nın "Tarihte Bugün" arşivinden seçtiğimiz olayları keşfedin.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="events">
+            {% if events %}
+                {% for event in events %}
+                    <article class="event-card">
+                        <div class="event-year">{{ event.year }}</div>
+                        <p class="event-text">{{ event.text }}</p>
+                        {% if event.pages %}
+                            <div class="event-links" aria-label="Daha fazla bilgi">
+                                {% for page in event.pages %}
+                                    <a href="{{ page.url }}" target="_blank" rel="noopener" class="event-link">{{ page.title }}</a>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </article>
+                {% endfor %}
+            {% else %}
+                <div class="empty-state">
+                    <h2>Olaylar yüklenemedi</h2>
+                    <p>Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.</p>
+                </div>
+            {% endif %}
+        </section>
+    </main>
+
+    <footer>
+        <p>Veriler <a href="https://www.wikipedia.org/" target="_blank" rel="noopener">Wikipedia</a>'dan alınmıştır.</p>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build a Flask view that fetches "On This Day" data from Wikipedia and prepares link metadata
- redesign the landing page with a minimal translucent theme and interactive cards for historical events
- document the new Tarihte Bugün experience in the README

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68d45dee684c8330b6e0ca5899fc5693