### PR TITLE
Render Turkish Wikipedia events with imagery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-#Flask
+# Tarihte Bugün
+Minimal ve şık tasarımlı bu web sayfası, Wikipedia'nın Türkçe "Tarihte Bugün" arşivinden çektiği içerikleri Türkçe olarak sunar. Her olay kartı, ilgili maddelere düzgün bağlantılar ve varsa öne çıkan görsellerle birlikte gelir.
+
+## Özellikler
+- Türkçe Wikipedia On This Day API'sinden günlük olayların otomatik olarak alınması
+- Olay kartlarında bağlantıların temiz bir şekilde gösterilmesi
+- İlgili maddelerden bulunan yüksek çözünürlüklü görsellerin (varsa) olay kartlarında yer alması
+- Minimal cam efektli tema ve mobil uyumlu düzen
+
+## Geliştirme
+Yerelde hızlıca incelemek için herhangi bir statik sunucu yeterlidir:
+
+```bash
+python -m http.server 8000
+```
+
+Ardından tarayıcınızda [`http://127.0.0.1:8000`](http://127.0.0.1:8000) adresini açın.
+
+Flask sürümünü çalıştırmak için:
+
+```bash
+pip install flask
+flask --app app.py run
+```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Tarihte Bugün
-Minimal ve şık tasarımlı bu web sayfası, Wikipedia'nın Türkçe "Tarihte Bugün" arşivinden çektiği içerikleri Türkçe olarak sunar. Her olay kartı, ilgili maddelere düzgün bağlantılar ve varsa öne çıkan görsellerle birlikte gelir.
+
+Minimal ve şık tasarımlı bu web sayfası, Wikipedia'nın Türkçe "Tarihte Bugün" arşivinden çektiği içerikleri tamamen statik şekilde sunar. Her olay kartı, ilgili maddelere düzgün bağlantılar ve varsa öne çıkan görsellerle birlikte gelir.
 
 ## Özellikler
-- Türkçe Wikipedia On This Day API'sinden günlük olayların otomatik olarak alınması
-- Olay kartlarında bağlantıların temiz bir şekilde gösterilmesi
-- İlgili maddelerden bulunan yüksek çözünürlüklü görsellerin (varsa) olay kartlarında yer alması
-- Minimal cam efektli tema ve mobil uyumlu düzen
+- Türkçe Wikipedia "On This Day" API'sinden (events, births, deaths, holidays, observances) günlük verilerin çekilmesi
+- Uzun metinler filtrelenerek kısa ve anlaşılır kartların gösterilmesi
+- Olay kartlarında bağlantıların HTML etiketleri olmadan temiz bir şekilde sunulması
+- İlgili maddelerden bulunan görsellerin (varsa) olay kartlarında yer alması
+- Minimal cam efektli tema, kategori rozetleri ve mobil uyumlu düzen
+- Tek tıkla yenileme düğmesi ile verilerin manuel olarak güncellenebilmesi
 
 ## Geliştirme
-Yerelde hızlıca incelemek için herhangi bir statik sunucu yeterlidir:
+Proje saf HTML/CSS/JS'ten oluştuğu için yerelde hızlıca incelemek üzere herhangi bir statik sunucu yeterlidir:
 
 ```bash
 python -m http.server 8000
@@ -16,9 +19,9 @@ python -m http.server 8000
 
 Ardından tarayıcınızda [`http://127.0.0.1:8000`](http://127.0.0.1:8000) adresini açın.
 
-Flask sürümünü çalıştırmak için:
+### GitHub Pages'e yayınlama
+1. Bu depoyu GitHub'da `main` dalına gönderin (push).
+2. Depo ayarlarından (Settings → Pages) kaynak olarak `main` ve `/` kök klasörünü seçin.
+3. Dakikalar içinde site `https://<kullanici-adiniz>.github.io/` adresinden erişilebilir olur.
 
-```bash
-pip install flask
-flask --app app.py run
-```
+İsteğe bağlı olarak `app.py` dosyası aynı verileri Flask ile servis ederek dinamik geliştirme senaryolarında kullanılabilir.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,48 @@
-# Tarihte Bugün
+# Tarihte Bugün – Yönetilebilir Tarih Akışı
 
-Minimal ve şık tasarımlı bu web sayfası, Wikipedia'nın Türkçe "Tarihte Bugün" arşivinden çektiği içerikleri tamamen statik şekilde sunar. Her olay kartı, ilgili maddelere düzgün bağlantılar ve varsa öne çıkan görsellerle birlikte gelir.
+Bu proje, Wikipedia'nın Türkçe “Tarihte Bugün” beslemesinden aldığı içerikleri cam etkili bir arayüzle sergileyen ve aynı zamanda yönetici paneli üzerinden tamamen kontrol edilebilir hale getiren bir Flask uygulamasıdır. İster otomatik olarak gelen olayları kullanın ister kendi haberlerinizi ekleyin; tüm bağlantılar temizlenir, görseller desteklenir ve düzenlemeler kolayca yapılır.
 
-## Özellikler
-- Türkçe Wikipedia "On This Day" API'sinden (events, births, deaths, holidays, observances) günlük verilerin çekilmesi
-- Uzun metinler filtrelenerek kısa ve anlaşılır kartların gösterilmesi
-- Olay kartlarında bağlantıların HTML etiketleri olmadan temiz bir şekilde sunulması
-- İlgili maddelerden bulunan görsellerin (varsa) olay kartlarında yer alması
-- Minimal cam efektli tema, kategori rozetleri ve mobil uyumlu düzen
-- Tek tıkla yenileme düğmesi ile verilerin manuel olarak güncellenebilmesi
+## Öne Çıkan Özellikler
+- 🎯 **Dinamik içerik deposu:** Türkçe “On This Day” API’sinden çekilen olaylar JSON dosyasında saklanır; yönetici panelinden düzenlenebilir veya elle eklenebilir.
+- 🖼️ **Zengin kart tasarımları:** Her kart kategori rozetleri, yıl bilgisi, görsel (varsa) ve temiz bağlantılarla cam efekti tema üzerinde sunulur.
+- 🛠️ **Yönetim paneli:** /admin üzerinden giriş yaparak içerikleri listeleyebilir, düzenleyebilir, silebilir veya tek tuşla bugünün olaylarını yeniden çekebilirsiniz.
+- 🔒 **Basit erişim kontrolü:** Ortam değişkenleriyle kullanıcı adı ve şifreyi belirleyin; oturum açanlar için ek navigasyon öğeleri otomatik görünür.
+- ⚡ **Hızlı deneyim:** Uzun metinler filtrelenir, görsel bağlantıları normalize edilir ve ön uçta hafif animasyonlarla kullanıcı deneyimi güçlendirilir.
 
-## Geliştirme
-Proje saf HTML/CSS/JS'ten oluştuğu için yerelde hızlıca incelemek üzere herhangi bir statik sunucu yeterlidir:
+## Kurulum
+1. Gerekli bağımlılıkları yükleyin:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows için .venv\Scripts\activate
+   pip install flask
+   ```
+2. Ortam değişkenlerini ayarlayın (isteğe bağlı):
+   ```bash
+   export FLASK_APP=app.py
+   export ADMIN_USERNAME=admin        # Varsayılan: admin
+   export ADMIN_PASSWORD=admin123     # Varsayılan: admin123
+   export SECRET_KEY=bir-super-sir    # Varsayılan: dev-secret-key
+   ```
+3. Uygulamayı çalıştırın:
+   ```bash
+   flask run
+   ```
+   Ardından tarayıcınızdan [http://127.0.0.1:5000](http://127.0.0.1:5000) adresini açın.
 
-```bash
-python -m http.server 8000
-```
+## Yönetim Paneli
+- `/admin/login` adresinden belirlediğiniz kullanıcı adı ve şifre ile giriş yapın.
+- **Bugünün Olaylarını Yenile:** Wikipedia'dan en fazla sekiz olay çekilerek var olan listeyi günceller.
+- **Yeni içerik ekle:** Başlık, özet, yıl, kategori, görsel ve kaynak bağlantılarını içeren kartlar oluşturabilirsiniz.
+- **Düzenle / Sil:** Var olan kartları güncelleyin veya kalıcı olarak kaldırın. Silme işlemleri için tarayıcı onayı alınır.
 
-Ardından tarayıcınızda [`http://127.0.0.1:8000`](http://127.0.0.1:8000) adresini açın.
+Tüm içerikler `data/events.json` dosyasında `last_refreshed` meta bilgisiyle birlikte saklanır; elle düzenlemeniz gerekiyorsa formatı koruduğunuzdan emin olun.
 
-### GitHub Pages'e yayınlama
-1. Bu depoyu GitHub'da `main` dalına gönderin (push).
-2. Depo ayarlarından (Settings → Pages) kaynak olarak `main` ve `/` kök klasörünü seçin.
-3. Dakikalar içinde site `https://<kullanici-adiniz>.github.io/` adresinden erişilebilir olur.
+## Statik Ön İzleme
+Depo kökündeki `index.html`, cam efekti temanın statik bir örneğini sunar ve GitHub Pages üzerinde bilgi amaçlı yayınlanabilir. Dinamik deneyim için Flask uygulamasını çalıştırmanız gerekir.
 
-İsteğe bağlı olarak `app.py` dosyası aynı verileri Flask ile servis ederek dinamik geliştirme senaryolarında kullanılabilir.
+## Geliştirme İpuçları
+- Yeni stiller eklerken `static/style.css` dosyasındaki değişkenleri kullanarak temayla uyum sağlayın.
+- JavaScript tarafında hafif animasyonlar ve formlarda silme onayı için `static/script.js` dosyasını güncelleyin.
+- Test amaçlı olarak `python -m compileall app.py` komutu ile sentaks kontrolü yapabilirsiniz.
+
+Katkılarınız ve geri bildirimleriniz için teşekkürler! 📬

--- a/app.py
+++ b/app.py
@@ -1,15 +1,29 @@
+import os
 from datetime import datetime
-from json import loads
+from functools import wraps
+from json import JSONDecodeError, dump, load, loads
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from uuid import uuid4
 
-from flask import Flask, render_template
+from flask import (
+    Flask,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 
 app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-secret-key")
 
 API_URL = "https://tr.wikipedia.org/api/rest_v1/feed/onthisday/all/{month}/{day}"
-USER_AGENT = "TarihteBugunApp/2.0 (https://github.com/zapotec001)"
+USER_AGENT = "TarihteBugunApp/3.0 (https://github.com/zapotec001)"
 CATEGORIES = ("selected", "events", "births", "deaths", "holidays", "observances")
 CATEGORY_LABELS = {
     "selected": "Öne Çıkanlar",
@@ -34,10 +48,16 @@ MONTH_NAMES_TR = [
     "Aralık",
 ]
 MAX_EVENTS = 9
-LENGTH_LIMIT = 240
+LENGTH_LIMIT = 260
+
+ADMIN_USERNAME = os.environ.get("ADMIN_USERNAME", "admin")
+ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "admin123")
+
+DATA_PATH = Path(app.root_path) / "data" / "events.json"
+DEFAULT_DATA: Dict[str, Any] = {"last_refreshed": None, "events": []}
 
 
-def _normalise_title(value: Optional[str]) -> str:
+def _normalise_whitespace(value: Optional[str]) -> str:
     if not value:
         return ""
     return " ".join(value.split())
@@ -50,16 +70,13 @@ def _normalise_pages(pages: Optional[List[Dict[str, Any]]]) -> List[Dict[str, st
         desktop_url = (content_urls.get("desktop") or {}).get("page")
         mobile_url = (content_urls.get("mobile") or {}).get("page")
         url = desktop_url or mobile_url
-        title = _normalise_title((page.get("titles") or {}).get("display") or page.get("title"))
-
+        title = _normalise_whitespace((page.get("titles") or {}).get("display") or page.get("title"))
         if not url or not title:
             continue
-
-        description = _normalise_title(page.get("description"))
+        description = _normalise_whitespace(page.get("description"))
         image_source = (page.get("originalimage") or {}).get("source") or (
             (page.get("thumbnail") or {}).get("source")
         )
-
         normalised.append(
             {
                 "title": title,
@@ -71,8 +88,59 @@ def _normalise_pages(pages: Optional[List[Dict[str, Any]]]) -> List[Dict[str, st
     return normalised
 
 
+def _format_timestamp(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    try:
+        cleaned = value.replace("Z", "+00:00")
+        moment = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    month_index = max(1, min(moment.month, len(MONTH_NAMES_TR))) - 1
+    return f"{moment.day:02d} {MONTH_NAMES_TR[month_index]} {moment.year} {moment.hour:02d}:{moment.minute:02d}"
+
+
+def _load_data() -> Dict[str, Any]:
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not DATA_PATH.exists():
+        _save_data(DEFAULT_DATA)
+        return {"last_refreshed": None, "events": []}
+
+    try:
+        with DATA_PATH.open("r", encoding="utf-8") as handle:
+            data = load(handle)
+    except (OSError, JSONDecodeError, ValueError):
+        return {"last_refreshed": None, "events": []}
+
+    raw_events = data.get("events") if isinstance(data, dict) else None
+    if not isinstance(raw_events, list):
+        raw_events = []
+    events: List[Dict[str, Any]] = []
+    for item in raw_events:
+        if not isinstance(item, dict):
+            continue
+        event_copy = item.copy()
+        event_copy.setdefault("id", str(uuid4()))
+        category = event_copy.get("category")
+        event_copy["category_label"] = CATEGORY_LABELS.get(category, category or "")
+        event_copy.setdefault("date_label", _format_today())
+        events.append(event_copy)
+    last_refreshed = data.get("last_refreshed") if isinstance(data, dict) else None
+    return {"last_refreshed": last_refreshed, "events": events}
+
+
+def _save_data(data: Dict[str, Any]) -> None:
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    to_save = {
+        "last_refreshed": data.get("last_refreshed"),
+        "events": data.get("events", []),
+    }
+    with DATA_PATH.open("w", encoding="utf-8") as handle:
+        dump(to_save, handle, ensure_ascii=False, indent=2)
+
+
 def fetch_today_events(limit: int = MAX_EVENTS, max_length: int = LENGTH_LIMIT) -> List[Dict[str, Any]]:
-    """Fetch notable events for today's date from Wikipedia and normalise them."""
+    """Fetch notable events for today's date from Turkish Wikipedia."""
 
     today = datetime.utcnow()
     url = API_URL.format(month=today.month, day=today.day)
@@ -88,14 +156,15 @@ def fetch_today_events(limit: int = MAX_EVENTS, max_length: int = LENGTH_LIMIT) 
 
     try:
         with urlopen(request, timeout=10) as response:
-            data = loads(response.read().decode("utf-8"))
-    except (URLError, HTTPError, ValueError):
+            payload = response.read().decode("utf-8")
+            data = loads(payload)
+    except (URLError, HTTPError, ValueError, TimeoutError, JSONDecodeError):
         return []
 
     aggregated: List[Dict[str, Any]] = []
     for category in CATEGORIES:
         for event in data.get(category, []) or []:
-            text = _normalise_title(event.get("text"))
+            text = _normalise_whitespace(event.get("text"))
             if not text or len(text) > max_length:
                 continue
             aggregated.append({"category": category, "event": event, "text": text})
@@ -122,7 +191,7 @@ def fetch_today_events(limit: int = MAX_EVENTS, max_length: int = LENGTH_LIMIT) 
         direct_image_url = (content_urls.get("desktop") or {}).get("page") or (
             (content_urls.get("mobile") or {}).get("page")
         )
-        extract = _normalise_title(event.get("extract"))
+        extract = _normalise_whitespace(event.get("extract"))
 
         image: Optional[Dict[str, Optional[str]]] = None
         if direct_image_src:
@@ -144,6 +213,7 @@ def fetch_today_events(limit: int = MAX_EVENTS, max_length: int = LENGTH_LIMIT) 
 
         normalised_events.append(
             {
+                "id": str(uuid4()),
                 "year": year,
                 "text": text,
                 "category": item["category"],
@@ -159,15 +229,240 @@ def fetch_today_events(limit: int = MAX_EVENTS, max_length: int = LENGTH_LIMIT) 
     return normalised_events
 
 
+def _create_entry_from_event(event: Dict[str, Any], date_label: str) -> Dict[str, Any]:
+    primary_page = event.get("pages", [{}])[0] if event.get("pages") else {}
+    image = event.get("image") or {}
+    return {
+        "id": event.get("id", str(uuid4())),
+        "title": primary_page.get("title") or event.get("text", "Tarihte Bugün"),
+        "summary": event.get("text", ""),
+        "year": event.get("year"),
+        "category": event.get("category"),
+        "category_label": event.get("category_label"),
+        "source_url": primary_page.get("url") or image.get("url") or "",
+        "source_title": primary_page.get("title") or "Wikipedia",
+        "image_url": image.get("src") or "",
+        "image_caption": image.get("caption") or "",
+        "image_credit_url": image.get("url") or primary_page.get("url") or "",
+        "date_label": date_label,
+        "created_at": datetime.utcnow().isoformat(),
+    }
+
+
+def ensure_events() -> Dict[str, Any]:
+    data = _load_data()
+    if data["events"]:
+        return data
+
+    today = datetime.utcnow()
+    date_label = f"{today.day:02d} {MONTH_NAMES_TR[today.month - 1]} {today.year}"
+    fetched = fetch_today_events(limit=6)
+    if not fetched:
+        return data
+
+    events = [_create_entry_from_event(event, date_label) for event in fetched]
+    payload = {"last_refreshed": datetime.utcnow().isoformat(), "events": events}
+    _save_data(payload)
+    return payload
+
+
+def _format_today() -> str:
+    today = datetime.utcnow()
+    return f"{today.day:02d} {MONTH_NAMES_TR[today.month - 1]} {today.year}"
+
+
+def _is_authenticated() -> bool:
+    return session.get("is_authenticated", False) is True
+
+
+def login_required(view_func):
+    @wraps(view_func)
+    def wrapper(*args, **kwargs):
+        if not _is_authenticated():
+            flash("Yönetim paneline erişmek için lütfen oturum açın.", "warning")
+            return redirect(url_for("admin_login"))
+        return view_func(*args, **kwargs)
+
+    return wrapper
+
+
+def _get_event(event_id: str) -> Optional[Dict[str, Any]]:
+    data = _load_data()
+    for item in data["events"]:
+        if item.get("id") == event_id:
+            return item
+    return None
+
+
+def _save_event(event: Dict[str, Any]) -> None:
+    data = _load_data()
+    events = data.get("events", [])
+    existing_index = next((index for index, item in enumerate(events) if item.get("id") == event["id"]), None)
+
+    if existing_index is None:
+        events.append(event)
+    else:
+        events[existing_index] = event
+
+    data["events"] = events
+    data["last_refreshed"] = data.get("last_refreshed") or datetime.utcnow().isoformat()
+    _save_data(data)
+
+
+def _delete_event(event_id: str) -> None:
+    data = _load_data()
+    events = [item for item in data.get("events", []) if item.get("id") != event_id]
+    data["events"] = events
+    _save_data(data)
+
+
+def _event_from_form(form: Dict[str, str], *, event_id: Optional[str] = None) -> Dict[str, Any]:
+    event = _get_event(event_id) if event_id else None
+    base: Dict[str, Any] = event.copy() if event else {"id": event_id or str(uuid4())}
+
+    year_value = form.get("year", "").strip()
+    year = None
+    if year_value:
+        try:
+            year = int(year_value)
+        except ValueError:
+            year = None
+
+    base.update(
+        {
+            "title": _normalise_whitespace(form.get("title", "")),
+            "summary": _normalise_whitespace(form.get("summary", "")),
+            "year": year,
+            "category": form.get("category") or "events",
+            "category_label": CATEGORY_LABELS.get(form.get("category"), form.get("category", "")),
+            "source_url": form.get("source_url", "").strip(),
+            "source_title": _normalise_whitespace(form.get("source_title", "")),
+            "image_url": form.get("image_url", "").strip(),
+            "image_caption": _normalise_whitespace(form.get("image_caption", "")),
+            "image_credit_url": form.get("image_credit_url", "").strip(),
+            "date_label": form.get("date_label", _format_today()),
+            "created_at": event.get("created_at") if event else datetime.utcnow().isoformat(),
+        }
+    )
+    return base
+
+
 @app.route("/")
 def home():
-    events = fetch_today_events()
-    today = datetime.utcnow()
+    data = ensure_events()
+    events = sorted(data.get("events", []), key=lambda item: item.get("year") or 0, reverse=True)
     return render_template(
         "index.html",
         events=events,
-        date_string=f"{today.day:02d} {MONTH_NAMES_TR[today.month - 1]} {today.year}",
+        last_refreshed=data.get("last_refreshed"),
+        last_refreshed_human=_format_timestamp(data.get("last_refreshed")),
+        today_label=_format_today(),
     )
+
+
+@app.route("/admin/login", methods=["GET", "POST"])
+def admin_login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "")
+
+        if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
+            session["is_authenticated"] = True
+            flash("Hoş geldiniz! Yönetim paneline giriş yaptınız.", "success")
+            return redirect(url_for("admin_dashboard"))
+
+        flash("Kullanıcı adı veya şifre hatalı.", "danger")
+    return render_template("admin/login.html")
+
+
+@app.route("/admin/logout")
+@login_required
+def admin_logout():
+    session.pop("is_authenticated", None)
+    flash("Oturum kapatıldı.", "info")
+    return redirect(url_for("home"))
+
+
+@app.route("/admin")
+@login_required
+def admin_dashboard():
+    data = _load_data()
+    events = sorted(data.get("events", []), key=lambda item: item.get("year") or 0, reverse=True)
+    return render_template(
+        "admin/dashboard.html",
+        events=events,
+        last_refreshed=data.get("last_refreshed"),
+        last_refreshed_human=_format_timestamp(data.get("last_refreshed")),
+    )
+
+
+@app.route("/admin/new", methods=["GET", "POST"])
+@login_required
+def admin_new():
+    if request.method == "POST":
+        event = _event_from_form(request.form)
+        _save_event(event)
+        flash("İçerik başarıyla eklendi.", "success")
+        return redirect(url_for("admin_dashboard"))
+
+    return render_template(
+        "admin/edit.html", event=None, categories=CATEGORY_LABELS, today_label=_format_today()
+    )
+
+
+@app.route("/admin/<event_id>/edit", methods=["GET", "POST"])
+@login_required
+def admin_edit(event_id: str):
+    event = _get_event(event_id)
+    if not event:
+        abort(404)
+
+    if request.method == "POST":
+        updated_event = _event_from_form(request.form, event_id=event_id)
+        _save_event(updated_event)
+        flash("İçerik güncellendi.", "success")
+        return redirect(url_for("admin_dashboard"))
+
+    return render_template(
+        "admin/edit.html",
+        event=event,
+        categories=CATEGORY_LABELS,
+        today_label=_format_today(),
+    )
+
+
+@app.route("/admin/<event_id>/delete", methods=["POST"])
+@login_required
+def admin_delete(event_id: str):
+    event = _get_event(event_id)
+    if not event:
+        abort(404)
+
+    _delete_event(event_id)
+    flash("İçerik silindi.", "info")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.route("/admin/refresh", methods=["POST"])
+@login_required
+def admin_refresh():
+    today = datetime.utcnow()
+    date_label = f"{today.day:02d} {MONTH_NAMES_TR[today.month - 1]} {today.year}"
+    fetched = fetch_today_events(limit=8)
+    if not fetched:
+        flash("Wikipedia verisi alınamadı. Daha sonra tekrar deneyin.", "danger")
+        return redirect(url_for("admin_dashboard"))
+
+    events = [_create_entry_from_event(event, date_label) for event in fetched]
+    payload = {"last_refreshed": datetime.utcnow().isoformat(), "events": events}
+    _save_data(payload)
+    flash("Bugünün olayları başarıyla yenilendi.", "success")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.context_processor
+def inject_utilities() -> Dict[str, Any]:
+    return {"datetime": datetime}
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -1,10 +1,122 @@
+from datetime import datetime
+from json import loads
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
 from flask import Flask, render_template
 
 app = Flask(__name__)
 
-@app.route('/')
-def home():
-    return render_template('index.html')
+API_URL = "https://tr.wikipedia.org/api/rest_v1/feed/onthisday/events/{month}/{day}"
+USER_AGENT = "TarihteBugunApp/1.0 (https://github.com/zapotec001)"
+MONTH_NAMES_TR = [
+    "Ocak",
+    "Şubat",
+    "Mart",
+    "Nisan",
+    "Mayıs",
+    "Haziran",
+    "Temmuz",
+    "Ağustos",
+    "Eylül",
+    "Ekim",
+    "Kasım",
+    "Aralık",
+]
 
-if __name__ == '__main__':
-    app.run()
+
+def _normalise_title(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return " ".join(value.split())
+
+
+def fetch_today_events(limit: int = 4) -> List[Dict[str, Any]]:
+    """Fetch notable events for today's date from Wikipedia."""
+    today = datetime.utcnow()
+    url = API_URL.format(month=today.month, day=today.day)
+
+    request = Request(
+        url,
+        headers={
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+            "Accept-Language": "tr",
+        },
+    )
+
+    try:
+        with urlopen(request, timeout=10) as response:
+            data = loads(response.read().decode("utf-8"))
+    except (URLError, HTTPError, ValueError):
+        return []
+
+    events = data.get("events", [])
+
+    # Sort by the year descending so the most recent events appear first
+    events.sort(key=lambda event: event.get("year", 0), reverse=True)
+
+    formatted_events = []
+    for event in events:
+        text = _normalise_title(event.get("text"))
+        if not text:
+            continue
+
+        page_links: List[Dict[str, str]] = []
+        primary_image: Optional[Dict[str, Any]] = None
+
+        for page in event.get("pages", []):
+            content_urls = (page.get("content_urls") or {}).get("desktop") or {}
+            desktop_url = content_urls.get("page")
+            title = _normalise_title((page.get("titles") or {}).get("display") or page.get("title"))
+
+            if not desktop_url or not title:
+                continue
+
+            description = _normalise_title(page.get("description"))
+            image_url = (page.get("originalimage") or {}).get("source") or (
+                (page.get("thumbnail") or {}).get("source")
+            )
+
+            page_links.append({"title": title, "url": desktop_url})
+
+            if not primary_image and image_url:
+                primary_image = {
+                    "src": image_url,
+                    "alt": title,
+                    "url": desktop_url,
+                    "caption": description or None,
+                }
+
+            if len(page_links) >= 2 and primary_image:
+                break
+
+        formatted_events.append(
+            {
+                "year": event.get("year"),
+                "text": text,
+                "pages": page_links[:2],
+                "image": primary_image,
+            }
+        )
+
+        if len(formatted_events) >= limit:
+            break
+
+    return formatted_events
+
+
+@app.route("/")
+def home():
+    events = fetch_today_events()
+    today = datetime.utcnow()
+    return render_template(
+        "index.html",
+        events=events,
+        date_string=f"{today.day:02d} {MONTH_NAMES_TR[today.month - 1]} {today.year}",
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,4 @@
+{
+  "last_refreshed": null,
+  "events": []
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,10 @@
         </nav>
         <div class="hero-content">
             <h1>Bugün Tarihte Neler Oldu?</h1>
-            <p>Wikipedia'nın "Tarihte Bugün" arşivinden seçtiğimiz olayları keşfedin.</p>
+            <p>Wikipedia'nın "Tarihte Bugün" arşivinden reklam içermeyen, kısa ve anlaşılır başlıca olayları keşfedin.</p>
+            <button class="refresh" type="button" data-refresh>
+                Bugünün olaylarını yenile
+            </button>
         </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tarihte Bugün</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="static/style.css">
+    <script defer src="static/script.js"></script>
+</head>
+<body>
+    <header class="hero">
+        <nav class="nav">
+            <div class="logo">Tarihte Bugün</div>
+            <div class="today" data-date></div>
+        </nav>
+        <div class="hero-content">
+            <h1>Bugün Tarihte Neler Oldu?</h1>
+            <p>Wikipedia'nın "Tarihte Bugün" arşivinden seçtiğimiz olayları keşfedin.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="events" id="events" aria-live="polite">
+            <div class="empty-state" id="status" role="status">
+                <h2>Olaylar yükleniyor</h2>
+                <p>Wikipedia'nın Tarihte Bugün arşivi çağrılıyor...</p>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>Veriler <a href="https://www.wikipedia.org/" target="_blank" rel="noopener">Wikipedia</a>'dan alınmıştır.</p>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,41 +1,167 @@
 <!DOCTYPE html>
 <html lang="tr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tarihte Bugün</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="static/style.css">
-    <script defer src="static/script.js"></script>
-</head>
-<body>
-    <header class="hero">
-        <nav class="nav">
-            <div class="logo">Tarihte Bugün</div>
-            <div class="today" data-date></div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tarihte Bugün - Yönetilebilir Haber Akışı</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="static/style.css" />
+    <script src="static/script.js" defer></script>
+  </head>
+  <body class="page">
+    <header class="site-header" data-animate>
+      <div class="site-header__inner">
+        <span class="brand">Tarihte Bugün</span>
+        <nav class="site-nav">
+          <a href="#icerikler">Anasayfa</a>
+          <a href="#panel" class="link-muted">Yönetim</a>
         </nav>
-        <div class="hero-content">
-            <h1>Bugün Tarihte Neler Oldu?</h1>
-            <p>Wikipedia'nın "Tarihte Bugün" arşivinden reklam içermeyen, kısa ve anlaşılır başlıca olayları keşfedin.</p>
-            <button class="refresh" type="button" data-refresh>
-                Bugünün olaylarını yenile
-            </button>
-        </div>
+      </div>
     </header>
 
-    <main>
-        <section class="events" id="events" aria-live="polite">
-            <div class="empty-state" id="status" role="status">
-                <h2>Olaylar yükleniyor</h2>
-                <p>Wikipedia'nın Tarihte Bugün arşivi çağrılıyor...</p>
+    <main class="page__content">
+      <section class="hero" data-animate>
+        <div class="hero__content">
+          <p class="hero__eyebrow">Canlı örnek</p>
+          <h1>Yönetilebilir “Tarihte Bugün” Deneyimi</h1>
+          <p class="hero__lead">
+            Bu depo, Wikipedia'nın Türkçe “Tarihte Bugün” beslemesinden öne çıkan
+            olayları çekip cam efektli bir arayüzde sergileyen Flask tabanlı bir
+            uygulama sağlar. Yönetim panelinden içerik ekleyebilir, düzenleyebilir
+            veya silebilirsiniz.
+          </p>
+          <div class="hero__meta">
+            <span class="meta-item">
+              <strong>Statik ön izleme</strong>
+              <span>Bu sayfa örnek veriler içerir</span>
+            </span>
+            <span class="meta-item">
+              <strong>Şu an saat:</strong>
+              <span data-clock aria-live="polite">--:--</span>
+            </span>
+          </div>
+          <div class="hero__actions">
+            <a class="button" href="#icerikler">Örnek olayları gör</a>
+            <a class="button button--ghost" href="#panel">Yönetim paneli</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="events" id="icerikler">
+        <div class="section-heading" data-animate>
+          <h2>Örnek İçerikler</h2>
+          <p>
+            Gerçek uygulamada bu kartlar Wikipedia'dan alınan güncel içerikler ve
+            yönetim panelinden girilen özel haberlerle değiştirilebilir.
+          </p>
+        </div>
+        <div class="events__grid">
+          <article class="event-card glass" data-animate>
+            <header class="event-card__header">
+              <span class="event-card__badge">Olay</span>
+              <span class="event-card__year">1920</span>
+            </header>
+            <figure class="event-card__figure">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/TBMM_acilisi.jpg/640px-TBMM_acilisi.jpg"
+                alt="Türkiye Büyük Millet Meclisi'nin açılışı"
+                loading="lazy"
+              />
+              <figcaption>TBMM, Ankara'da görkemli bir törenle açıldı.</figcaption>
+            </figure>
+            <div class="event-card__body">
+              <h3>Türkiye Büyük Millet Meclisi açıldı</h3>
+              <p>
+                Mustafa Kemal Paşa'nın çağrısıyla Ankara'da toplanan Birinci Meclis,
+                Türk Kurtuluş Savaşı'nı yönetecek yasama organı olarak göreve
+                başladı.
+              </p>
+              <p class="event-card__date">23 Nisan 1920</p>
             </div>
-        </section>
+            <footer class="event-card__footer">
+              <a
+                class="button button--link"
+                href="https://tr.wikipedia.org/wiki/T%C3%BCrkiye_B%C3%BCy%C3%BCk_Millet_Meclisi"
+                target="_blank"
+                rel="noopener"
+                >Wikipedia kaynağı</a
+              >
+            </footer>
+          </article>
+
+          <article class="event-card glass" data-animate>
+            <header class="event-card__header">
+              <span class="event-card__badge">Öne Çıkanlar</span>
+              <span class="event-card__year">1961</span>
+            </header>
+            <div class="event-card__body">
+              <h3>İlk insanlı uzay uçuşu başarıyla tamamlandı</h3>
+              <p>
+                Yuri Gagarin, Vostok 1 kapsülü ile Dünya yörüngesine çıkarak uzaya
+                giden ilk insan oldu ve 108 dakikalık bir uçuş gerçekleştirdi.
+              </p>
+              <p class="event-card__date">12 Nisan 1961</p>
+            </div>
+            <footer class="event-card__footer">
+              <a
+                class="button button--link"
+                href="https://tr.wikipedia.org/wiki/Yuri_Gagarin"
+                target="_blank"
+                rel="noopener"
+                >Wikipedia kaynağı</a
+              >
+            </footer>
+          </article>
+        </div>
+      </section>
+
+      <section class="events" id="panel">
+        <div class="section-heading" data-animate>
+          <h2>Yönetim Paneli Özellikleri</h2>
+          <p>
+            <strong>app.py</strong> dosyasındaki Flask uygulamasını çalıştırarak
+            /admin adresinden şu işlemleri yapabilirsiniz:
+          </p>
+        </div>
+        <div class="events__grid">
+          <article class="event-card glass" data-animate>
+            <div class="event-card__body">
+              <h3>Otomatik veri yenileme</h3>
+              <p>
+                Tek tıkla Wikipedia'dan bugüne ait en fazla sekiz olayı çekip cam
+                efektli kartlara dönüştürün. Uzun metinler filtrelenir, görseller ve
+                bağlantılar otomatik temizlenir.
+              </p>
+            </div>
+          </article>
+          <article class="event-card glass" data-animate>
+            <div class="event-card__body">
+              <h3>El ile düzenleme ve ekleme</h3>
+              <p>
+                Her kartın başlığını, özetini, görselini ve kaynak bağlantısını
+                güncelleyebilir veya yeni içerikler oluşturabilirsiniz. Silme
+                işlemleri için ek onay alınır.
+              </p>
+            </div>
+          </article>
+        </div>
+      </section>
     </main>
 
-    <footer>
-        <p>Veriler <a href="https://www.wikipedia.org/" target="_blank" rel="noopener">Wikipedia</a>'dan alınmıştır.</p>
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>© <span class="brand">Tarihte Bugün</span> – Yönetilebilir tarih akışı.</p>
+        <p>
+          Yerel geliştirme için <code>python -m flask --app app.py run</code>
+          komutunu çalıştırın ve <code>ADMIN_PASSWORD</code> ortam değişkeniyle
+          giriş bilgilerinizi özelleştirin.
+        </p>
+      </div>
     </footer>
-</body>
+  </body>
 </html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,15 +1,239 @@
-function updateClock() {
-    var now = new Date();
-    var hours = now.getHours();
-    var minutes = now.getMinutes();
-    var seconds = now.getSeconds();
+const nav = document.querySelector(".nav");
+let statusElement = document.getElementById("status");
+const eventsContainer = document.getElementById("events");
+const todayElement = document.querySelector("[data-date]");
 
-    hours = hours.toString().padStart(2, '0');
-    minutes = minutes.toString().padStart(2, '0');
-    seconds = seconds.toString().padStart(2, '0');
+const observer = new IntersectionObserver(
+    (entries) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add("is-visible");
+                observer.unobserve(entry.target);
+            }
+        });
+    },
+    { threshold: 0.2 }
+);
 
-    var timeString = hours + ':' + minutes + ':' + seconds;
-    document.getElementById('clock').textContent = timeString;
+function updateNavOnScroll() {
+    if (!nav) return;
+    if (window.scrollY > 40) {
+        nav.classList.add("nav--scrolled");
+    } else {
+        nav.classList.remove("nav--scrolled");
+    }
 }
 
-setInterval(updateClock, 1000);
+document.addEventListener("scroll", updateNavOnScroll);
+
+function formatDate(now = new Date()) {
+    return now.toLocaleDateString("tr-TR", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+function showStatus(title, message, role = "status") {
+    if (!statusElement) {
+        statusElement = document.createElement("div");
+        statusElement.className = "empty-state";
+        statusElement.id = "status";
+        statusElement.setAttribute("role", role);
+        eventsContainer?.appendChild(statusElement);
+    }
+
+    statusElement.innerHTML = `<h2>${title}</h2><p>${message}</p>`;
+    statusElement.setAttribute("role", role);
+}
+
+function clearStatus() {
+    if (statusElement) {
+        statusElement.remove();
+        statusElement = null;
+    }
+}
+
+function createEventCard(event) {
+    const article = document.createElement("article");
+    article.className = "event-card will-animate";
+
+    const year = document.createElement("div");
+    year.className = "event-year";
+    year.textContent = event.year ?? "";
+
+    const text = document.createElement("p");
+    text.className = "event-text";
+    text.textContent = event.text ?? "";
+
+    article.appendChild(year);
+    if (event.image?.src) {
+        const figure = document.createElement("figure");
+        figure.className = "event-media";
+
+        const img = document.createElement("img");
+        img.src = event.image.src;
+        img.alt = event.image.alt || "Olay görseli";
+        img.loading = "lazy";
+
+        if (event.image.url) {
+            const imageLink = document.createElement("a");
+            imageLink.href = event.image.url;
+            imageLink.target = "_blank";
+            imageLink.rel = "noopener";
+            imageLink.className = "event-image-link";
+            imageLink.appendChild(img);
+            figure.appendChild(imageLink);
+        } else {
+            figure.appendChild(img);
+        }
+
+        if (event.image.caption) {
+            const figcaption = document.createElement("figcaption");
+            figcaption.textContent = event.image.caption;
+            figure.appendChild(figcaption);
+        }
+
+        article.appendChild(figure);
+    }
+    article.appendChild(text);
+
+    if (Array.isArray(event.pages) && event.pages.length > 0) {
+        const linksWrapper = document.createElement("div");
+        linksWrapper.className = "event-links";
+        linksWrapper.setAttribute("aria-label", "Daha fazla bilgi");
+
+        event.pages.slice(0, 2).forEach((page) => {
+            const url = page?.url;
+            const title = page?.title;
+            if (!url || !title) return;
+
+            const link = document.createElement("a");
+            link.href = url;
+            link.target = "_blank";
+            link.rel = "noopener";
+            link.className = "event-link";
+            link.textContent = title;
+            linksWrapper.appendChild(link);
+        });
+
+        if (linksWrapper.children.length > 0) {
+            article.appendChild(linksWrapper);
+        }
+    }
+
+    observer.observe(article);
+    return article;
+}
+
+async function loadEvents(referenceDate = new Date()) {
+    if (!eventsContainer) return;
+
+    eventsContainer.innerHTML = "";
+    statusElement = null;
+    showStatus(
+        "Olaylar yükleniyor",
+        "Wikipedia'nın Tarihte Bugün arşivi çağrılıyor..."
+    );
+
+    const month = referenceDate.getMonth() + 1;
+    const day = referenceDate.getDate();
+    const endpoint = `https://tr.wikipedia.org/api/rest_v1/feed/onthisday/events/${month}/${day}`;
+
+    try {
+        const response = await fetch(endpoint, {
+            headers: {
+                Accept: "application/json",
+                "Accept-Language": "tr",
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error("Yanıt alınamadı");
+        }
+
+        const data = await response.json();
+        const events = Array.isArray(data.events) ? data.events : [];
+
+        const sorted = events
+            .filter((event) => event.text)
+            .sort((a, b) => (b.year || 0) - (a.year || 0))
+            .slice(0, 4);
+
+        if (sorted.length === 0) {
+            showStatus(
+                "Olay bulunamadı",
+                "Bugün için Wikipedia'da listelenen olay yok.",
+                "alert"
+            );
+            return;
+        }
+
+        clearStatus();
+        const normalisedEvents = sorted.map((event) => {
+            const pages = Array.isArray(event.pages)
+                ? event.pages
+                      .map((page) => {
+                          const desktopUrl =
+                              page?.content_urls?.desktop?.page ||
+                              page?.content_urls?.mobile?.page;
+                          const title = (page?.titles?.display || page?.title || "")
+                              .replace(/\s+/g, " ")
+                              .trim();
+                          const description = (page?.description || "").trim();
+                          const imageSource =
+                              page?.originalimage?.source || page?.thumbnail?.source || "";
+
+                          if (!desktopUrl || !title) {
+                              return null;
+                          }
+
+                          return {
+                              title,
+                              url: desktopUrl,
+                              description,
+                              imageSource,
+                          };
+                      })
+                      .filter(Boolean)
+                : [];
+
+            const primaryImage = pages.find((page) => page.imageSource);
+
+            return {
+                year: event.year,
+                text: event.text?.trim() || "",
+                pages: pages.slice(0, 2).map(({ title, url }) => ({ title, url })),
+                image: primaryImage
+                    ? {
+                          src: primaryImage.imageSource,
+                          alt: primaryImage.title,
+                          url: primaryImage.url,
+                          caption: primaryImage.description || null,
+                      }
+                    : null,
+            };
+        });
+
+        normalisedEvents.forEach((event) => {
+            const card = createEventCard(event);
+            eventsContainer.appendChild(card);
+        });
+    } catch (error) {
+        console.error("Olaylar yüklenirken hata oluştu", error);
+        showStatus(
+            "Olaylar yüklenemedi",
+            "Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.",
+            "alert"
+        );
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const now = new Date();
+    if (todayElement) {
+        todayElement.textContent = formatDate(now);
+    }
+    updateNavOnScroll();
+    loadEvents(now);
+});

--- a/static/script.js
+++ b/static/script.js
@@ -1,333 +1,58 @@
-const nav = document.querySelector(".nav");
-let statusElement = document.getElementById("status");
-const eventsContainer = document.getElementById("events");
-const todayElement = document.querySelector("[data-date]");
-const refreshButton = document.querySelector("[data-refresh]");
-const refreshDefaultLabel = refreshButton?.textContent?.trim() || "";
+const animatedItems = document.querySelectorAll("[data-animate]");
+const confirmForms = document.querySelectorAll("form[data-confirm]");
+const clockElement = document.querySelector("[data-clock]");
+const scrollLinks = document.querySelectorAll('a[href^="#"]');
 
-const LENGTH_LIMIT = 240;
-const MAX_EVENTS = 9;
-const CATEGORY_LABELS = {
-    selected: "Öne Çıkanlar",
-    events: "Olay",
-    births: "Doğum",
-    deaths: "Ölüm",
-    holidays: "Özel Gün",
-    observances: "Anma",
-};
-
-const observer = new IntersectionObserver(
-    (entries) => {
-        entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-                entry.target.classList.add("is-visible");
-                observer.unobserve(entry.target);
-            }
-        });
+if ("IntersectionObserver" in window) {
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("is-visible");
+          obs.unobserve(entry.target);
+        }
+      });
     },
     { threshold: 0.2 }
-);
+  );
 
-function updateNavOnScroll() {
-    if (!nav) return;
-    if (window.scrollY > 40) {
-        nav.classList.add("nav--scrolled");
-    } else {
-        nav.classList.remove("nav--scrolled");
-    }
+  animatedItems.forEach((item) => observer.observe(item));
+} else {
+  animatedItems.forEach((item) => item.classList.add("is-visible"));
 }
 
-document.addEventListener("scroll", updateNavOnScroll);
+confirmForms.forEach((form) => {
+  form.addEventListener("submit", (event) => {
+    const message = form.getAttribute("data-confirm-message") ||
+      "Bu içeriği silmek istediğinizden emin misiniz?";
+    if (!window.confirm(message)) {
+      event.preventDefault();
+    }
+  });
+});
 
-function formatDate(now = new Date()) {
-    return now.toLocaleDateString("tr-TR", {
-        day: "2-digit",
-        month: "long",
-        year: "numeric",
-    });
+function updateClock() {
+  if (!clockElement) return;
+  const now = new Date();
+  clockElement.textContent = now.toLocaleTimeString("tr-TR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
-function showStatus(title, message, role = "status") {
-    if (!statusElement) {
-        statusElement = document.createElement("div");
-        statusElement.className = "empty-state";
-        statusElement.id = "status";
-        statusElement.setAttribute("role", role);
-        eventsContainer?.appendChild(statusElement);
-    }
-
-    statusElement.innerHTML = `<h2>${title}</h2><p>${message}</p>`;
-    statusElement.setAttribute("role", role);
+if (clockElement) {
+  updateClock();
+  setInterval(updateClock, 1000);
 }
 
-function setRefreshLoading(isLoading) {
-    if (!refreshButton) return;
-    refreshButton.disabled = isLoading;
-    refreshButton.classList.toggle("is-loading", isLoading);
-    if (refreshDefaultLabel) {
-        refreshButton.textContent = isLoading
-            ? "Yenileniyor..."
-            : refreshDefaultLabel;
-    }
-}
-
-function clearStatus() {
-    if (statusElement) {
-        statusElement.remove();
-        statusElement = null;
-    }
-}
-
-function formatCategory(category) {
-    if (!category) return "";
-    return CATEGORY_LABELS[category] || category;
-}
-
-function createEventCard(event) {
-    const article = document.createElement("article");
-    article.className = "event-card will-animate";
-
-    const meta = document.createElement("header");
-    meta.className = "event-meta";
-
-    if (event.category) {
-        const badge = document.createElement("span");
-        badge.className = `event-category event-category--${event.category}`;
-        badge.textContent = formatCategory(event.category);
-        meta.appendChild(badge);
-    }
-
-    const year = document.createElement("span");
-    year.className = "event-year";
-    year.textContent = event.year ?? "";
-    meta.appendChild(year);
-
-    article.appendChild(meta);
-
-    const text = document.createElement("p");
-    text.className = "event-text";
-    text.textContent = event.text ?? "";
-
-    if (event.image?.src) {
-        const figure = document.createElement("figure");
-        figure.className = "event-media";
-
-        const img = document.createElement("img");
-        img.src = event.image.src;
-        img.alt = event.image.alt || "Olay görseli";
-        img.loading = "lazy";
-
-        if (event.image.url) {
-            const imageLink = document.createElement("a");
-            imageLink.href = event.image.url;
-            imageLink.target = "_blank";
-            imageLink.rel = "noopener";
-            imageLink.className = "event-image-link";
-            imageLink.appendChild(img);
-            figure.appendChild(imageLink);
-        } else {
-            figure.appendChild(img);
-        }
-
-        if (event.image.caption) {
-            const figcaption = document.createElement("figcaption");
-            figcaption.textContent = event.image.caption;
-            figure.appendChild(figcaption);
-        }
-
-        article.appendChild(figure);
-    }
-    article.appendChild(text);
-
-    if (Array.isArray(event.pages) && event.pages.length > 0) {
-        const linksWrapper = document.createElement("div");
-        linksWrapper.className = "event-links";
-        linksWrapper.setAttribute("aria-label", "Daha fazla bilgi");
-
-        event.pages.slice(0, 2).forEach((page) => {
-            const url = page?.url;
-            const title = page?.title;
-            if (!url || !title) return;
-
-            const link = document.createElement("a");
-            link.href = url;
-            link.target = "_blank";
-            link.rel = "noopener";
-            link.className = "event-link";
-            link.textContent = title;
-            linksWrapper.appendChild(link);
-        });
-
-        if (linksWrapper.children.length > 0) {
-            article.appendChild(linksWrapper);
-        }
-    }
-
-    observer.observe(article);
-    return article;
-}
-
-async function loadEvents(referenceDate = new Date()) {
-    if (!eventsContainer) return;
-
-    eventsContainer.innerHTML = "";
-    statusElement = null;
-    showStatus(
-        "Olaylar yükleniyor",
-        "Wikipedia'nın Tarihte Bugün arşivi çağrılıyor..."
-    );
-
-    const month = referenceDate.getMonth() + 1;
-    const day = referenceDate.getDate();
-    const endpoint = `https://tr.wikipedia.org/api/rest_v1/feed/onthisday/all/${month}/${day}`;
-
-    setRefreshLoading(true);
-    try {
-        const response = await fetch(endpoint, {
-            headers: {
-                Accept: "application/json",
-                "Accept-Language": "tr",
-            },
-        });
-
-        if (!response.ok) {
-            throw new Error("Yanıt alınamadı");
-        }
-
-        const data = await response.json();
-        const categories = [
-            { key: "selected", items: data.selected },
-            { key: "events", items: data.events },
-            { key: "births", items: data.births },
-            { key: "deaths", items: data.deaths },
-            { key: "holidays", items: data.holidays },
-            { key: "observances", items: data.observances },
-        ];
-
-        const aggregated = categories.flatMap(({ key, items }) => {
-            if (!Array.isArray(items)) return [];
-            return items.map((item) => ({ ...item, category: key }));
-        });
-
-        const filtered = aggregated
-            .filter((event) => {
-                const text = event?.text?.trim();
-                return text && text.length <= LENGTH_LIMIT;
-            })
-            .sort((a, b) => (b.year || 0) - (a.year || 0));
-
-        const deduplicated = [];
-        const seen = new Set();
-        for (const event of filtered) {
-            const key = `${event.year || "unknown"}-${event.text}`.toLowerCase();
-            if (seen.has(key)) continue;
-            seen.add(key);
-            deduplicated.push(event);
-            if (deduplicated.length >= MAX_EVENTS) {
-                break;
-            }
-        }
-
-        if (deduplicated.length === 0) {
-            showStatus(
-                "Olay bulunamadı",
-                "Bugün için Wikipedia'da listelenen olay yok.",
-                "alert"
-            );
-            return;
-        }
-
-        clearStatus();
-        const normalisedEvents = deduplicated.map((event) => {
-            const pages = Array.isArray(event.pages)
-                ? event.pages
-                      .map((page) => {
-                          const desktopUrl =
-                              page?.content_urls?.desktop?.page ||
-                              page?.content_urls?.mobile?.page;
-                          const title = (page?.titles?.display || page?.title || "")
-                              .replace(/\s+/g, " ")
-                              .trim();
-                          const description = (page?.description || "").trim();
-                          const imageSource =
-                              page?.originalimage?.source || page?.thumbnail?.source || "";
-
-                          if (!desktopUrl || !title) {
-                              return null;
-                          }
-
-                          return {
-                              title,
-                              url: desktopUrl,
-                              description,
-                              imageSource,
-                          };
-                      })
-                      .filter(Boolean)
-                : [];
-
-            const directImageSrc =
-                event?.originalimage?.source || event?.thumbnail?.source || "";
-            const directImageUrl =
-                event?.content_urls?.desktop?.page || event?.content_urls?.mobile?.page || "";
-
-            let image = null;
-            if (directImageSrc) {
-                image = {
-                    src: directImageSrc,
-                    alt: event.text?.trim() || "Olay görseli",
-                    url: directImageUrl || pages[0]?.url || null,
-                    caption: event?.extract ? event.extract.trim() : null,
-                };
-            } else {
-                const pageWithImage = pages.find((page) => page.imageSource);
-                if (pageWithImage) {
-                    image = {
-                        src: pageWithImage.imageSource,
-                        alt: pageWithImage.title,
-                        url: pageWithImage.url,
-                        caption: pageWithImage.description || null,
-                    };
-                }
-            }
-
-            return {
-                year: event.year,
-                text: event.text?.trim() || "",
-                category: event.category,
-                pages: pages.slice(0, 3).map(({ title, url }) => ({ title, url })),
-                image,
-            };
-        });
-
-        normalisedEvents.forEach((event) => {
-            const card = createEventCard(event);
-            eventsContainer.appendChild(card);
-        });
-    } catch (error) {
-        console.error("Olaylar yüklenirken hata oluştu", error);
-        showStatus(
-            "Olaylar yüklenemedi",
-            "Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.",
-            "alert"
-        );
-    } finally {
-        setRefreshLoading(false);
-    }
-}
-
-document.addEventListener("DOMContentLoaded", () => {
-    const now = new Date();
-    if (todayElement) {
-        todayElement.textContent = formatDate(now);
-    }
-    updateNavOnScroll();
-    loadEvents(now);
-    refreshButton?.addEventListener("click", () => {
-        const refreshedDate = new Date();
-        if (todayElement) {
-            todayElement.textContent = formatDate(refreshedDate);
-        }
-        loadEvents(refreshedDate);
-    });
+scrollLinks.forEach((link) => {
+  link.addEventListener("click", (event) => {
+    const targetId = link.getAttribute("href")?.slice(1);
+    const target = targetId ? document.getElementById(targetId) : null;
+    if (!target) return;
+    event.preventDefault();
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    target.classList.add("is-visible");
+  });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -55,9 +55,13 @@ body {
     color: var(--text-secondary);
 }
 
+
 .hero-content {
     margin-top: 6rem;
     max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 .hero-content h1 {
@@ -70,6 +74,33 @@ body {
     color: var(--text-secondary);
 }
 
+.refresh {
+    align-self: flex-start;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(15, 32, 39, 0.55);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+
+.refresh:hover,
+.refresh:focus-visible {
+    background: rgba(243, 198, 35, 0.25);
+    border-color: rgba(243, 198, 35, 0.6);
+    transform: translateY(-2px);
+}
+
+.refresh.is-loading,
+.refresh:disabled {
+    cursor: wait;
+    opacity: 0.65;
+    transform: none;
+}
+
 main {
     flex: 1;
     padding: 0 4vw 4rem;
@@ -77,6 +108,7 @@ main {
 
 .events {
     display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 1.5rem;
     margin-top: -3rem;
 }
@@ -128,11 +160,51 @@ main {
     transform: scale(1.02);
 }
 
+.event-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.event-category {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(243, 198, 35, 0.4);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(243, 198, 35, 0.9);
+    background: rgba(243, 198, 35, 0.12);
+}
+
+.event-category--births {
+    color: rgba(138, 214, 255, 0.9);
+    border-color: rgba(138, 214, 255, 0.4);
+    background: rgba(138, 214, 255, 0.12);
+}
+
+.event-category--deaths {
+    color: rgba(255, 143, 143, 0.9);
+    border-color: rgba(255, 143, 143, 0.4);
+    background: rgba(255, 143, 143, 0.12);
+}
+
+.event-category--holidays,
+.event-category--observances {
+    color: rgba(186, 255, 174, 0.9);
+    border-color: rgba(186, 255, 174, 0.4);
+    background: rgba(186, 255, 174, 0.12);
+}
+
 .event-year {
-    font-size: 1.5rem;
+    font-size: 1.4rem;
     font-weight: 600;
     color: var(--accent);
-    margin-bottom: 0.75rem;
 }
 
 .event-text {
@@ -197,6 +269,11 @@ footer a:hover {
 
     .hero-content {
         margin-top: 4rem;
+    }
+
+    .refresh {
+        width: 100%;
+        text-align: center;
     }
 
     .event-card {

--- a/static/style.css
+++ b/static/style.css
@@ -1,298 +1,556 @@
 :root {
-    --bg-gradient-start: #0f2027;
-    --bg-gradient-middle: #203a43;
-    --bg-gradient-end: #2c5364;
-    --card-bg: rgba(255, 255, 255, 0.08);
-    --card-border: rgba(255, 255, 255, 0.25);
-    --accent: #f3c623;
-    --text-primary: #f7f7f7;
-    --text-secondary: rgba(247, 247, 247, 0.75);
-    --link: #8ad6ff;
+  color-scheme: dark light;
+  --bg-gradient: radial-gradient(circle at 0% 0%, #4f7cff 0%, transparent 55%),
+    radial-gradient(circle at 100% 0%, #8e6bff 0%, transparent 55%),
+    linear-gradient(135deg, #0b1220, #0e1a2f 55%, #1a223b);
+  --glass-bg: rgba(20, 26, 46, 0.72);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f3f4fb;
+  --text-secondary: rgba(243, 244, 251, 0.76);
+  --accent: #8e8cff;
+  --accent-strong: #62d5ff;
+  --danger: #ff6b6b;
+  --success: #7cd992;
+  --warning: #f2c94c;
+  --muted: rgba(255, 255, 255, 0.45);
+  --radius-xl: 32px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --shadow: 0 20px 60px rgba(8, 15, 35, 0.35);
+  --font-body: "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+  box-sizing: border-box;
 }
 
-body {
-    font-family: "Poppins", sans-serif;
-    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-middle), var(--bg-gradient-end));
-    color: var(--text-primary);
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
+body.page {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  background-attachment: fixed;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.page__content {
+  flex: 1;
+  width: min(1100px, calc(100% - 3rem));
+  margin: 0 auto;
+  padding: 7rem 0 4rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(10, 16, 28, 0.72);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-header__inner {
+  width: min(1100px, calc(100% - 3rem));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0.5rem;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.site-nav a.link-muted {
+  color: var(--muted);
+}
+
+.flash-container {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.flash {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  box-shadow: var(--shadow);
+}
+
+.flash--success {
+  border-color: rgba(124, 217, 146, 0.45);
+}
+
+.flash--danger {
+  border-color: rgba(255, 107, 107, 0.45);
+}
+
+.flash--warning {
+  border-color: rgba(242, 201, 76, 0.45);
+}
+
+.flash--info {
+  border-color: rgba(142, 140, 255, 0.45);
 }
 
 .hero {
-    position: relative;
-    padding: 2rem 4vw 4rem;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent);
+  margin-bottom: 4rem;
 }
 
-.nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    position: sticky;
-    top: 0;
-    padding: 1rem 0;
-    backdrop-filter: blur(10px);
-    background: rgba(15, 32, 39, 0.4);
-    border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    padding-inline: clamp(1rem, 4vw, 2rem);
+.hero__content {
+  padding: 3rem;
+  border-radius: var(--radius-xl);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow);
 }
 
-.logo {
-    font-weight: 600;
-    letter-spacing: 0.05em;
+.hero__eyebrow {
+  color: var(--accent-strong);
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
 }
 
-.today {
-    font-weight: 300;
-    color: var(--text-secondary);
+.hero h1 {
+  font-size: clamp(2.4rem, 5vw, 3.1rem);
+  margin: 0 0 1rem;
 }
 
-
-.hero-content {
-    margin-top: 6rem;
-    max-width: 640px;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
+.hero__lead {
+  margin: 0 0 2rem;
+  max-width: 52ch;
+  color: var(--text-secondary);
+  line-height: 1.7;
 }
 
-.hero-content h1 {
-    font-size: clamp(2.5rem, 6vw, 3.5rem);
-    margin-bottom: 1rem;
+.hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  margin-bottom: 2rem;
+  color: var(--text-secondary);
 }
 
-.hero-content p {
-    font-size: clamp(1rem, 2.5vw, 1.2rem);
-    color: var(--text-secondary);
+.meta-item strong {
+  display: block;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  margin-bottom: 0.4rem;
 }
 
-.refresh {
-    align-self: flex-start;
-    padding: 0.85rem 1.8rem;
-    border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    background: rgba(15, 32, 39, 0.55);
-    color: var(--text-primary);
-    font-size: 0.95rem;
-    letter-spacing: 0.02em;
-    cursor: pointer;
-    transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+.hero__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
-.refresh:hover,
-.refresh:focus-visible {
-    background: rgba(243, 198, 35, 0.25);
-    border-color: rgba(243, 198, 35, 0.6);
-    transform: translateY(-2px);
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  border: none;
+  color: #0c1220;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  text-decoration: none;
 }
 
-.refresh.is-loading,
-.refresh:disabled {
-    cursor: wait;
-    opacity: 0.65;
-    transform: none;
+.button:hover,
+.button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(98, 213, 255, 0.35);
 }
 
-main {
-    flex: 1;
-    padding: 0 4vw 4rem;
+.button--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: none;
 }
 
-.events {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.5rem;
-    margin-top: -3rem;
+.button--ghost:hover,
+.button--ghost:focus {
+  box-shadow: 0 12px 24px rgba(12, 18, 32, 0.35);
+}
+
+.button--link {
+  background: transparent;
+  color: var(--accent-strong);
+  padding: 0;
+  box-shadow: none;
+  font-weight: 600;
+}
+
+.button--danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+.button--small {
+  padding: 0.55rem 1.1rem;
+  font-size: 0.85rem;
+}
+
+.events__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.section-heading {
+  max-width: 65ch;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.glass {
+  background: var(--glass-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
 }
 
 .event-card {
-    background: var(--card-bg);
-    border: 1px solid var(--card-border);
-    border-radius: 24px;
-    padding: 2rem;
-    backdrop-filter: blur(12px);
-    transition: transform 0.3s ease, border-color 0.3s ease;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 100%;
 }
 
-.event-card:hover {
-    transform: translateY(-6px);
-    border-color: rgba(243, 198, 35, 0.5);
+.event-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 1.5rem 0.75rem;
+  gap: 1rem;
 }
 
-.event-media {
-    margin-bottom: 1.25rem;
-    border-radius: 18px;
-    overflow: hidden;
-    background: rgba(15, 32, 39, 0.4);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+.event-card__badge {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent-strong);
 }
 
-.event-media img {
-    width: 100%;
-    height: auto;
-    display: block;
-    object-fit: cover;
+.event-card__year {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-secondary);
 }
 
-.event-media figcaption {
-    padding: 0.75rem 1rem 0.9rem;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    background: rgba(15, 32, 39, 0.35);
+.event-card__figure {
+  margin: 0 1.5rem;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.event-image-link {
-    display: block;
-    transition: transform 0.3s ease;
+.event-card__figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
 }
 
-.event-image-link:hover,
-.event-image-link:focus {
-    transform: scale(1.02);
+.event-card__figure figcaption {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  background: rgba(0, 0, 0, 0.22);
 }
 
-.event-meta {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
+.event-card__body {
+  padding: 1.5rem;
+  flex: 1;
 }
 
-.event-category {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.35rem 0.9rem;
-    border-radius: 999px;
-    border: 1px solid rgba(243, 198, 35, 0.4);
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: rgba(243, 198, 35, 0.9);
-    background: rgba(243, 198, 35, 0.12);
+.event-card__body h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.3rem;
 }
 
-.event-category--births {
-    color: rgba(138, 214, 255, 0.9);
-    border-color: rgba(138, 214, 255, 0.4);
-    background: rgba(138, 214, 255, 0.12);
+.event-card__body p {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
-.event-category--deaths {
-    color: rgba(255, 143, 143, 0.9);
-    border-color: rgba(255, 143, 143, 0.4);
-    background: rgba(255, 143, 143, 0.12);
+.event-card__date {
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
 }
 
-.event-category--holidays,
-.event-category--observances {
-    color: rgba(186, 255, 174, 0.9);
-    border-color: rgba(186, 255, 174, 0.4);
-    background: rgba(186, 255, 174, 0.12);
-}
-
-.event-year {
-    font-size: 1.4rem;
-    font-weight: 600;
-    color: var(--accent);
-}
-
-.event-text {
-    line-height: 1.6;
-    color: var(--text-secondary);
-    margin-bottom: 1rem;
-}
-
-.event-links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-}
-
-.event-link {
-    text-decoration: none;
-    color: var(--link);
-    border: 1px solid rgba(138, 214, 255, 0.4);
-    padding: 0.4rem 0.9rem;
-    border-radius: 999px;
-    font-size: 0.85rem;
-    transition: background 0.3s ease, color 0.3s ease;
-}
-
-.event-link:hover,
-.event-link:focus {
-    background: rgba(138, 214, 255, 0.2);
-    color: #ffffff;
+.event-card__footer {
+  padding: 0 1.5rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
 }
 
 .empty-state {
-    text-align: center;
-    background: var(--card-bg);
-    border: 1px solid var(--card-border);
-    border-radius: 24px;
-    padding: 3rem 2rem;
-    backdrop-filter: blur(12px);
-    color: var(--text-secondary);
+  text-align: center;
+  padding: 3rem;
+  border-radius: var(--radius-lg);
+  background: rgba(12, 19, 34, 0.75);
+  border: 1px dashed rgba(255, 255, 255, 0.18);
 }
 
-footer {
-    text-align: center;
-    padding: 2rem;
-    color: var(--text-secondary);
-    font-size: 0.9rem;
+.empty-state h2,
+.empty-state h3 {
+  margin-top: 0;
 }
 
-footer a {
-    color: var(--link);
-    text-decoration: none;
+.site-footer {
+  padding: 2rem 1.5rem 3rem;
+  color: var(--muted);
+  text-align: center;
 }
 
-footer a:hover {
-    text-decoration: underline;
+.site-footer__inner {
+  width: min(1100px, calc(100% - 3rem));
+  margin: 0 auto;
+  display: grid;
+  gap: 0.75rem;
 }
 
-@media (max-width: 768px) {
-    .nav {
-        flex-direction: column;
-        gap: 0.5rem;
-    }
-
-    .hero-content {
-        margin-top: 4rem;
-    }
-
-    .refresh {
-        width: 100%;
-        text-align: center;
-    }
-
-    .event-card {
-        padding: 1.5rem;
-    }
+.auth,
+.dashboard,
+.editor {
+  display: grid;
+  gap: 2rem;
 }
 
-.nav--scrolled {
-    background: rgba(15, 32, 39, 0.75);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+.auth__panel {
+  padding: 2.5rem;
+  text-align: center;
 }
 
-.will-animate {
-    opacity: 0;
-    transform: translateY(20px);
-    transition: transform 0.6s ease, opacity 0.6s ease;
+.form {
+  display: grid;
+  gap: 1.5rem;
 }
 
-.is-visible {
-    opacity: 1;
-    transform: translateY(0);
+.form__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form__field {
+  display: grid;
+  gap: 0.5rem;
+  text-align: left;
+}
+
+.form__field input,
+.form__field select,
+.form__field textarea {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(5, 9, 18, 0.65);
+  color: var(--text-primary);
+  padding: 0.85rem 1rem;
+  font: inherit;
+  resize: vertical;
+}
+
+.form__field input:focus,
+.form__field select:focus,
+.form__field textarea:focus {
+  outline: 2px solid rgba(142, 140, 255, 0.45);
+}
+
+.form__fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form__fieldset legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+}
+
+.form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.preview {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.preview img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.dashboard__header,
+.editor__header {
+  padding: 2rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dashboard__actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.dashboard__table {
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 1rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  vertical-align: top;
+}
+
+.table thead th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+
+.table__summary {
+  margin: 0.4rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.table__actions {
+  white-space: nowrap;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.table__actions form {
+  margin: 0;
+}
+
+[data-animate] {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 600ms ease, transform 600ms ease;
+}
+
+[data-animate].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 720px) {
+  .page__content {
+    width: calc(100% - 2rem);
+    padding-top: 6rem;
+  }
+
+  .hero__content {
+    padding: 2.25rem;
+  }
+
+  .dashboard__header,
+  .editor__header {
+    padding: 1.5rem;
+  }
+
+  .dashboard__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .site-nav {
+    gap: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  [data-animate] {
+    opacity: 1 !important;
+    transform: none !important;
+  }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,221 @@
+:root {
+    --bg-gradient-start: #0f2027;
+    --bg-gradient-middle: #203a43;
+    --bg-gradient-end: #2c5364;
+    --card-bg: rgba(255, 255, 255, 0.08);
+    --card-border: rgba(255, 255, 255, 0.25);
+    --accent: #f3c623;
+    --text-primary: #f7f7f7;
+    --text-secondary: rgba(247, 247, 247, 0.75);
+    --link: #8ad6ff;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: "Poppins", sans-serif;
+    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-middle), var(--bg-gradient-end));
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.hero {
+    position: relative;
+    padding: 2rem 4vw 4rem;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent);
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    padding: 1rem 0;
+    backdrop-filter: blur(10px);
+    background: rgba(15, 32, 39, 0.4);
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding-inline: clamp(1rem, 4vw, 2rem);
+}
+
+.logo {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.today {
+    font-weight: 300;
+    color: var(--text-secondary);
+}
+
+.hero-content {
+    margin-top: 6rem;
+    max-width: 640px;
+}
+
+.hero-content h1 {
+    font-size: clamp(2.5rem, 6vw, 3.5rem);
+    margin-bottom: 1rem;
+}
+
+.hero-content p {
+    font-size: clamp(1rem, 2.5vw, 1.2rem);
+    color: var(--text-secondary);
+}
+
+main {
+    flex: 1;
+    padding: 0 4vw 4rem;
+}
+
+.events {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: -3rem;
+}
+
+.event-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 24px;
+    padding: 2rem;
+    backdrop-filter: blur(12px);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.event-card:hover {
+    transform: translateY(-6px);
+    border-color: rgba(243, 198, 35, 0.5);
+}
+
+.event-media {
+    margin-bottom: 1.25rem;
+    border-radius: 18px;
+    overflow: hidden;
+    background: rgba(15, 32, 39, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.event-media img {
+    width: 100%;
+    height: auto;
+    display: block;
+    object-fit: cover;
+}
+
+.event-media figcaption {
+    padding: 0.75rem 1rem 0.9rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    background: rgba(15, 32, 39, 0.35);
+}
+
+.event-image-link {
+    display: block;
+    transition: transform 0.3s ease;
+}
+
+.event-image-link:hover,
+.event-image-link:focus {
+    transform: scale(1.02);
+}
+
+.event-year {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--accent);
+    margin-bottom: 0.75rem;
+}
+
+.event-text {
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+}
+
+.event-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.event-link {
+    text-decoration: none;
+    color: var(--link);
+    border: 1px solid rgba(138, 214, 255, 0.4);
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.event-link:hover,
+.event-link:focus {
+    background: rgba(138, 214, 255, 0.2);
+    color: #ffffff;
+}
+
+.empty-state {
+    text-align: center;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 24px;
+    padding: 3rem 2rem;
+    backdrop-filter: blur(12px);
+    color: var(--text-secondary);
+}
+
+footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+footer a {
+    color: var(--link);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    .nav {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .hero-content {
+        margin-top: 4rem;
+    }
+
+    .event-card {
+        padding: 1.5rem;
+    }
+}
+
+.nav--scrolled {
+    background: rgba(15, 32, 39, 0.75);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.will-animate {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: transform 0.6s ease, opacity 0.6s ease;
+}
+
+.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+{% block title %}Yönetim Paneli - Tarihte Bugün{% endblock %}
+
+{% block content %}
+<section class="dashboard" data-animate>
+  <div class="dashboard__header glass">
+    <div>
+      <h1>İçerik Yönetimi</h1>
+      <p>
+        Bugünün olaylarını görüntüleyin, düzenleyin veya yeni içerikler ekleyin.
+        {% if last_refreshed_human %}
+        Son otomatik güncelleme: <strong>{{ last_refreshed_human }}</strong>.
+        {% endif %}
+      </p>
+    </div>
+    <div class="dashboard__actions">
+      <form method="post" action="{{ url_for('admin_refresh') }}">
+        <button type="submit" class="button">Bugünün Olaylarını Yenile</button>
+      </form>
+      <a class="button button--ghost" href="{{ url_for('admin_new') }}">Yeni içerik ekle</a>
+    </div>
+  </div>
+
+  <div class="dashboard__table glass">
+    {% if events %}
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Başlık</th>
+          <th>Yıl</th>
+          <th>Kategori</th>
+          <th>Kaynak</th>
+          <th class="table__actions">İşlemler</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for event in events %}
+        <tr>
+          <td>
+            <strong>{{ event.title }}</strong>
+            {% if event.summary %}
+            <p class="table__summary">{{ event.summary }}</p>
+            {% endif %}
+          </td>
+          <td>{{ event.year or "-" }}</td>
+          <td>{{ event.category_label or event.category }}</td>
+          <td>
+            {% if event.source_url %}
+            <a href="{{ event.source_url }}" target="_blank" rel="noopener">{{ event.source_title or 'Bağlantı' }}</a>
+            {% else %}
+            Yok
+            {% endif %}
+          </td>
+          <td class="table__actions">
+            <a class="button button--small" href="{{ url_for('admin_edit', event_id=event.id) }}">Düzenle</a>
+            <form
+              method="post"
+              action="{{ url_for('admin_delete', event_id=event.id) }}"
+              data-confirm
+              data-confirm-message="{{ event.title }} başlıklı içeriği silmek istediğinizden emin misiniz?"
+            >
+              <button type="submit" class="button button--danger button--small">Sil</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="empty-state">
+      <h2>Hiç içerik yok</h2>
+      <p>
+        “Bugünün Olaylarını Yenile” düğmesini kullanarak Wikipedia’dan yeni
+        içerik çekebilir veya kendi haberlerinizi ekleyebilirsiniz.
+      </p>
+      <a class="button" href="{{ url_for('admin_new') }}">Yeni içerik ekle</a>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/admin/edit.html
+++ b/templates/admin/edit.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% if event %}
+  {% set page_title = 'İçeriği Düzenle' %}
+{% else %}
+  {% set page_title = 'Yeni İçerik Ekle' %}
+{% endif %}
+
+{% block title %}{{ page_title }} - Tarihte Bugün{% endblock %}
+
+{% block content %}
+<section class="editor" data-animate>
+  <div class="editor__header glass">
+    <h1>{{ page_title }}</h1>
+    <p>Başlığı, özeti, görselleri ve bağlantıları düzenleyebilir, yeni içerikler ekleyebilirsiniz.</p>
+  </div>
+  <form method="post" class="form glass editor__form">
+    <div class="form__grid">
+      <label class="form__field">
+        <span>Başlık</span>
+        <input type="text" name="title" value="{{ event.title if event else '' }}" required />
+      </label>
+      <label class="form__field">
+        <span>Yıl</span>
+        <input type="number" name="year" value="{{ event.year if event and event.year else '' }}" min="-5000" max="{{ datetime.utcnow().year }}" />
+      </label>
+      <label class="form__field">
+        <span>Kategori</span>
+        <select name="category">
+          {% for key, label in categories.items() %}
+          <option value="{{ key }}" {% if event and event.category == key %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="form__field">
+        <span>Görünecek Tarih</span>
+        <input type="text" name="date_label" value="{{ event.date_label if event else today_label }}" placeholder="Örn. 05 Nisan 2024" />
+      </label>
+    </div>
+
+    <label class="form__field">
+      <span>Özet</span>
+      <textarea name="summary" rows="4" required>{{ event.summary if event else '' }}</textarea>
+    </label>
+
+    <fieldset class="form__fieldset">
+      <legend>Kaynak Bilgileri</legend>
+      <div class="form__grid">
+        <label class="form__field">
+          <span>Kaynak Başlığı</span>
+          <input type="text" name="source_title" value="{{ event.source_title if event else '' }}" />
+        </label>
+        <label class="form__field">
+          <span>Kaynak URL</span>
+          <input type="url" name="source_url" value="{{ event.source_url if event else '' }}" />
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset class="form__fieldset">
+      <legend>Görsel</legend>
+      <div class="form__grid">
+        <label class="form__field">
+          <span>Görsel URL</span>
+          <input type="url" name="image_url" value="{{ event.image_url if event else '' }}" />
+        </label>
+        <label class="form__field">
+          <span>Görsel Açıklaması</span>
+          <input type="text" name="image_caption" value="{{ event.image_caption if event else '' }}" />
+        </label>
+        <label class="form__field">
+          <span>Görsel Kaynak URL</span>
+          <input type="url" name="image_credit_url" value="{{ event.image_credit_url if event else '' }}" />
+        </label>
+      </div>
+      {% if event and event.image_url %}
+      <div class="preview">
+        <img src="{{ event.image_url }}" alt="{{ event.title }}" loading="lazy" />
+      </div>
+      {% endif %}
+    </fieldset>
+
+    <div class="form__actions">
+      <a class="button button--ghost" href="{{ url_for('admin_dashboard') }}">Vazgeç</a>
+      <button type="submit" class="button">Kaydet</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Yönetim Girişi - Tarihte Bugün{% endblock %}
+
+{% block content %}
+<section class="auth" data-animate>
+  <div class="glass auth__panel">
+    <h1>Yönetim Paneli</h1>
+    <p>İçerikleri düzenlemek için kullanıcı adı ve şifrenizi girin.</p>
+    <form method="post" class="form">
+      <label class="form__field">
+        <span>Kullanıcı adı</span>
+        <input type="text" name="username" autocomplete="username" required />
+      </label>
+      <label class="form__field">
+        <span>Şifre</span>
+        <input type="password" name="password" autocomplete="current-password" required />
+      </label>
+      <button type="submit" class="button">Giriş yap</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Tarihte Bugün{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  </head>
+  <body class="page">
+    <header class="site-header" data-animate>
+      <div class="site-header__inner">
+        <a class="brand" href="{{ url_for('home') }}">Tarihte Bugün</a>
+        <nav class="site-nav">
+          <a href="{{ url_for('home') }}">Anasayfa</a>
+          {% if session.get('is_authenticated') %}
+          <a href="{{ url_for('admin_dashboard') }}">Yönetim</a>
+          <a href="{{ url_for('admin_logout') }}" class="link-muted">Çıkış</a>
+          {% else %}
+          <a href="{{ url_for('admin_login') }}" class="link-muted">Giriş</a>
+          {% endif %}
+        </nav>
+      </div>
+    </header>
+
+    <main id="main" class="page__content">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <div class="flash-container" role="status">
+        {% for category, message in messages %}
+        <div class="flash flash--{{ category }}" data-animate>{{ message }}</div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
+
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>
+          <span aria-hidden="true">©</span>
+          <span>{{ datetime.utcnow().year }}</span>
+          <span class="brand">Tarihte Bugün</span>
+        </p>
+        <p>
+          Veriler Türkçe Wikipedia “On This Day” beslemesinden alınır ve yönetim
+          paneli ile düzenlenebilir.
+        </p>
+      </div>
+    </footer>
+    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,10 @@
         </nav>
         <div class="hero-content">
             <h1>Bugün Tarihte Neler Oldu?</h1>
-            <p>Wikipedia'nın "Tarihte Bugün" arşivinden seçtiğimiz olayları keşfedin.</p>
+            <p>Wikipedia'nın "Tarihte Bugün" arşivinden reklam içermeyen, kısa ve anlaşılır başlıca olayları keşfedin.</p>
+            <button class="refresh" type="button" data-refresh>
+                Bugünün olaylarını yenile
+            </button>
         </div>
     </header>
 
@@ -27,7 +30,12 @@
             {% if events %}
                 {% for event in events %}
                     <article class="event-card">
-                        <div class="event-year">{{ event.year }}</div>
+                        <header class="event-meta">
+                            {% if event.category_label %}
+                                <span class="event-category event-category--{{ event.category }}">{{ event.category_label }}</span>
+                            {% endif %}
+                            <span class="event-year">{{ event.year }}</span>
+                        </header>
                         {% if event.image %}
                             <figure class="event-media">
                                 {% if event.image.url %}
@@ -65,7 +73,7 @@
                     </article>
                 {% endfor %}
             {% else %}
-                <div class="empty-state">
+                <div class="empty-state" id="status" role="status">
                     <h2>Olaylar yüklenemedi</h2>
                     <p>Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.</p>
                 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,88 +1,104 @@
-<!DOCTYPE html>
-<html lang="tr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tarihte Bugün</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
-    <script defer src="{{ url_for('static', filename='script.js') }}"></script>
-</head>
-<body>
-    <header class="hero">
-        <nav class="nav">
-            <div class="logo">Tarihte Bugün</div>
-            <div class="today" data-date>{{ date_string }}</div>
-        </nav>
-        <div class="hero-content">
-            <h1>Bugün Tarihte Neler Oldu?</h1>
-            <p>Wikipedia'nın "Tarihte Bugün" arşivinden reklam içermeyen, kısa ve anlaşılır başlıca olayları keşfedin.</p>
-            <button class="refresh" type="button" data-refresh>
-                Bugünün olaylarını yenile
-            </button>
-        </div>
-    </header>
+{% extends "base.html" %}
 
-    <main>
-        <section class="events" id="events" aria-live="polite">
-            {% if events %}
-                {% for event in events %}
-                    <article class="event-card">
-                        <header class="event-meta">
-                            {% if event.category_label %}
-                                <span class="event-category event-category--{{ event.category }}">{{ event.category_label }}</span>
-                            {% endif %}
-                            <span class="event-year">{{ event.year }}</span>
-                        </header>
-                        {% if event.image %}
-                            <figure class="event-media">
-                                {% if event.image.url %}
-                                    <a
-                                        href="{{ event.image.url }}"
-                                        target="_blank"
-                                        rel="noopener"
-                                        class="event-image-link"
-                                    >
-                                        <img src="{{ event.image.src }}" alt="{{ event.image.alt }}" loading="lazy" />
-                                    </a>
-                                {% else %}
-                                    <img src="{{ event.image.src }}" alt="{{ event.image.alt }}" loading="lazy" />
-                                {% endif %}
-                                {% if event.image.caption %}
-                                    <figcaption>{{ event.image.caption }}</figcaption>
-                                {% endif %}
-                            </figure>
-                        {% endif %}
-                        <p class="event-text">{{ event.text }}</p>
-                        {% if event.pages %}
-                            <div class="event-links" aria-label="Daha fazla bilgi">
-                                {% for page in event.pages %}
-                                    <a
-                                        href="{{ page.url }}"
-                                        target="_blank"
-                                        rel="noopener"
-                                        class="event-link"
-                                    >
-                                        {{ page.title }}
-                                    </a>
-                                {% endfor %}
-                            </div>
-                        {% endif %}
-                    </article>
-                {% endfor %}
-            {% else %}
-                <div class="empty-state" id="status" role="status">
-                    <h2>Olaylar yüklenemedi</h2>
-                    <p>Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.</p>
-                </div>
-            {% endif %}
-        </section>
-    </main>
+{% block title %}Tarihte Bugün - Bugün Neler Oldu?{% endblock %}
 
-    <footer>
-        <p>Veriler <a href="https://www.wikipedia.org/" target="_blank" rel="noopener">Wikipedia</a>'dan alınmıştır.</p>
-    </footer>
-</body>
-</html>
+{% block content %}
+<section class="hero" data-animate>
+  <div class="hero__content">
+    <p class="hero__eyebrow">{{ today_label }}</p>
+    <h1>Tarihte Bugün Neler Oldu?</h1>
+    <p class="hero__lead">
+      Türkçe Wikipedia kayıtlarından derlenen öne çıkan olayları her gün şeffaf
+      bir tasarımda sunuyoruz. Yönetim paneliyle içerikleri dilediğiniz gibi
+      düzenleyebilir, yeni detaylar ekleyebilirsiniz.
+    </p>
+    <div class="hero__meta">
+      {% if last_refreshed_human %}
+      <span class="meta-item">
+        <strong>Son güncelleme:</strong>
+        <span>{{ last_refreshed_human }}</span>
+      </span>
+      {% endif %}
+      <span class="meta-item">
+        <strong>İçerik sayısı:</strong>
+        <span>{{ events|length }}</span>
+      </span>
+      <span class="meta-item">
+        <strong>Şu an saat:</strong>
+        <span data-clock aria-live="polite">--:--</span>
+      </span>
+    </div>
+    <div class="hero__actions">
+      <a class="button" href="#icerikler">Olayları keşfet</a>
+      <a class="button button--ghost" href="{{ url_for('admin_login') }}">
+        Yönetim girişi
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="events" id="icerikler">
+  <div class="section-heading" data-animate>
+    <h2>Bugünün Öne Çıkanları</h2>
+    <p>
+      Aşağıdaki içerikler otomatik olarak Wikipedia’dan alınır ve yönetici
+      panelinden düzenlenebilir. Uzun metinler filtrelenir, bağlantılar temizlenir
+      ve mümkün olduğunda görseller eklenir.
+    </p>
+  </div>
+
+  {% if events %}
+  <div class="events__grid">
+    {% for event in events %}
+    <article class="event-card glass" data-animate>
+      <header class="event-card__header">
+        <span class="event-card__badge">{{ event.category_label }}</span>
+        {% if event.year %}
+        <span class="event-card__year">{{ event.year }}</span>
+        {% endif %}
+      </header>
+
+      {% if event.image_url %}
+      <figure class="event-card__figure">
+        <img src="{{ event.image_url }}" alt="{{ event.title }}" loading="lazy" />
+        {% if event.image_caption %}
+        <figcaption>{{ event.image_caption }}</figcaption>
+        {% endif %}
+      </figure>
+      {% endif %}
+
+      <div class="event-card__body">
+        <h3>{{ event.title }}</h3>
+        <p>{{ event.summary }}</p>
+        {% if event.date_label %}
+        <p class="event-card__date">{{ event.date_label }}</p>
+        {% endif %}
+      </div>
+
+      <footer class="event-card__footer">
+        {% if event.source_url %}
+        <a class="button button--link" href="{{ event.source_url }}" target="_blank" rel="noopener">
+          {{ event.source_title or 'Wikipedia kaynağı' }}
+        </a>
+        {% endif %}
+        {% if event.image_credit_url and event.image_credit_url != event.source_url %}
+        <a class="button button--link" href="{{ event.image_credit_url }}" target="_blank" rel="noopener">
+          Görsel kaynağı
+        </a>
+        {% endif %}
+      </footer>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="empty-state glass" data-animate>
+    <h3>Henüz içerik bulunamadı</h3>
+    <p>
+      Yönetim paneline giriş yapıp “Bugünün Olaylarını Yenile” düğmesiyle güncel
+      haberleri yükleyebilir veya özel içerikler ekleyebilirsiniz.
+    </p>
+    <a class="button" href="{{ url_for('admin_login') }}">Yönetim paneline git</a>
+  </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,80 @@
 <!DOCTYPE html>
-<html>
+<html lang="tr">
 <head>
-    <title>GitHub Sayfası</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tarihte Bugün</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
-    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <script defer src="{{ url_for('static', filename='script.js') }}"></script>
 </head>
 <body>
-    <h1>GitHub Sayfası</h1>
-    <div id="clock"></div>
+    <header class="hero">
+        <nav class="nav">
+            <div class="logo">Tarihte Bugün</div>
+            <div class="today" data-date>{{ date_string }}</div>
+        </nav>
+        <div class="hero-content">
+            <h1>Bugün Tarihte Neler Oldu?</h1>
+            <p>Wikipedia'nın "Tarihte Bugün" arşivinden seçtiğimiz olayları keşfedin.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="events" id="events" aria-live="polite">
+            {% if events %}
+                {% for event in events %}
+                    <article class="event-card">
+                        <div class="event-year">{{ event.year }}</div>
+                        {% if event.image %}
+                            <figure class="event-media">
+                                {% if event.image.url %}
+                                    <a
+                                        href="{{ event.image.url }}"
+                                        target="_blank"
+                                        rel="noopener"
+                                        class="event-image-link"
+                                    >
+                                        <img src="{{ event.image.src }}" alt="{{ event.image.alt }}" loading="lazy" />
+                                    </a>
+                                {% else %}
+                                    <img src="{{ event.image.src }}" alt="{{ event.image.alt }}" loading="lazy" />
+                                {% endif %}
+                                {% if event.image.caption %}
+                                    <figcaption>{{ event.image.caption }}</figcaption>
+                                {% endif %}
+                            </figure>
+                        {% endif %}
+                        <p class="event-text">{{ event.text }}</p>
+                        {% if event.pages %}
+                            <div class="event-links" aria-label="Daha fazla bilgi">
+                                {% for page in event.pages %}
+                                    <a
+                                        href="{{ page.url }}"
+                                        target="_blank"
+                                        rel="noopener"
+                                        class="event-link"
+                                    >
+                                        {{ page.title }}
+                                    </a>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </article>
+                {% endfor %}
+            {% else %}
+                <div class="empty-state">
+                    <h2>Olaylar yüklenemedi</h2>
+                    <p>Şu anda Wikipedia verilerine erişilemiyor. Lütfen daha sonra tekrar deneyin.</p>
+                </div>
+            {% endif %}
+        </section>
+    </main>
+
+    <footer>
+        <p>Veriler <a href="https://www.wikipedia.org/" target="_blank" rel="noopener">Wikipedia</a>'dan alınmıştır.</p>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- localise the Tarihte Bugün data pipeline to the Turkish Wikipedia feed with cleaned links and optional imagery
- enrich the front-end to display event visuals, captions, and Turkish copy with polished styling
- document the refreshed experience and add Flask run instructions in the README

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68d45dee684c8330b6e0ca5899fc5693